### PR TITLE
Переделать визуальный стиль: светлый редакционный семейный архив

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1,150 +1,213 @@
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Manrope:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&display=swap');
+
+/* Светлый цифровой семейный архив в редакционной эстетике:
+   молочная бумага, тонкие линии, сливовый и серо-оливковый акценты.
+   Никаких тёмных плашек, градиентов и имитации пергамента. */
 :root{
-  --bg:#13060D; --bg2:#2A0C1E; --card:#3A1028; --card-soft:rgba(58,16,40,.72);
-  --ivory:#F3EDE7; --pearl:#DDD3CB; --taupe:#B9AAA2; --tech:#907983;
-  --champ:#D2B48C; --champ2:#B99A72;
-  --green:#0E8F4B; --green-h:#0A6E3A; --mint:#39C270;
-  --line:#4A2A39; --border:#5B3446; --orange:#D2622F; --orange-t:#E08A5E;
+  --paper:#F4F0E8;
+  --paper-deep:#EDE8DE;
+  --surface:#FCFAF6;
+  --ink:#252321;
+  --ink-2:#756F68;
+  /* Мелкий текст (12–14 px) затемнён относительно --ink-2:
+     на молочном фоне вторичный тон иначе не добирает контраста. */
+  --ink-3:#5C574F;
+  --plum:#76536C;
+  --plum-deep:#5D4155;
+  --plum-tint:rgba(118,83,108,.09);
+  --olive:#7B806C;
+  --olive-ink:#5C6150;
+  --olive-tint:rgba(123,128,108,.14);
+  --line:#D8D0C5;
+  --line-soft:#E7E1D6;
+  --line-strong:#C4BAAB;
+  --serif:'Cormorant Garamond',Georgia,'Times New Roman',serif;
+  --sans:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;
+  --shadow:0 1px 2px rgba(37,35,33,.03),0 10px 28px rgba(37,35,33,.05);
+  --radius:14px;
 }
 *{margin:0;padding:0;box-sizing:border-box}
-html{scroll-behavior:smooth}
-body{background:var(--bg);color:var(--pearl);font-family:'Manrope',system-ui,sans-serif;font-size:17px;line-height:1.55;overflow-x:hidden}
-h1,h2,h3,h4{font-family:'Cormorant Garamond',Georgia,serif;color:var(--ivory);font-weight:500}
-.wrap{max-width:1180px;margin:0 auto;padding:0 32px}
-.label{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--champ);font-weight:600}
-section{padding:80px 0}
-.sect-head{margin-bottom:46px}
-.sect-head h2{font-size:clamp(30px,4vw,50px);margin-top:12px}
-.sect-head p{color:var(--taupe);max-width:780px;margin-top:12px}
-.hr{height:1px;background:linear-gradient(90deg,var(--champ2),transparent);width:120px;margin-top:20px;opacity:.6}
+html{scroll-behavior:smooth;-webkit-text-size-adjust:100%}
+body{background:var(--paper);color:var(--ink);font-family:var(--sans);font-size:18px;line-height:1.62;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+h1,h2,h3,h4{font-family:var(--serif);color:var(--ink);font-weight:500;letter-spacing:-.005em}
+b,strong{font-weight:600;color:var(--ink)}
+:focus-visible{outline:2px solid var(--plum);outline-offset:3px;border-radius:4px}
+.wrap{max-width:1120px;margin:0 auto;padding:0 34px}
+section{padding:96px 0}
+.alt{background:var(--paper-deep)}
 .numtab{font-variant-numeric:tabular-nums}
 
+/* Надзаголовок с короткой линейкой — единственный постоянный декоративный элемент */
+.label{display:inline-flex;align-items:center;gap:11px;font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--plum);font-weight:600;line-height:1.4}
+.label::before{content:"";width:26px;height:1px;background:var(--plum);opacity:.5;flex-shrink:0}
+.sect-head{margin-bottom:54px;max-width:840px}
+.sect-head h2{font-size:clamp(32px,4.4vw,52px);line-height:1.08;margin-top:18px}
+.sect-head p{color:var(--ink-2);margin-top:18px;font-size:17px}
+.hr{height:1px;background:var(--line);width:180px;margin-top:28px}
+
 /* NAV */
-nav{position:sticky;top:0;z-index:50;background:rgba(19,6,13,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
-nav .wrap{display:flex;align-items:center;gap:10px;padding-top:14px;padding-bottom:14px}
-nav .brand{font-family:'Cormorant Garamond',serif;font-size:20px;color:var(--ivory);margin-right:auto;font-weight:600}
-.navbtn{background:none;border:1px solid transparent;color:var(--taupe);font-family:'Manrope';font-size:14px;font-weight:600;padding:10px 20px;border-radius:12px;cursor:pointer;transition:.2s}
-.navbtn:hover{color:var(--ivory)}
-.navbtn.active{background:var(--green);color:var(--ivory)}
+nav{position:sticky;top:0;z-index:50;background:rgba(244,240,232,.93);backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+nav .wrap{display:flex;align-items:center;gap:8px;padding-top:16px;padding-bottom:16px}
+nav .brand{font-family:var(--serif);font-size:21px;font-weight:600;color:var(--ink);margin-right:auto}
+.navbtn{background:none;border:none;color:var(--ink-2);font-family:var(--sans);font-size:14.5px;font-weight:500;padding:9px 18px;border-radius:10px;cursor:pointer;transition:color .18s,background .18s}
+.navbtn:hover{color:var(--ink);background:rgba(37,35,33,.04)}
+.navbtn.active{background:var(--plum-tint);color:var(--plum);font-weight:600}
 .page{display:none}
 .page.visible{display:block}
 
 /* HERO */
-.hero{padding:90px 0 66px;background:radial-gradient(circle at 20% 30%, #3A1028 0%, #2A0C1E 35%, #13060D 80%);position:relative;overflow:hidden}
-.hero::before{content:"";position:absolute;right:-140px;top:-140px;width:520px;height:520px;border:1px solid rgba(185,154,114,.18);border-radius:50%}
-.hero::after{content:"";position:absolute;right:80px;top:160px;width:240px;height:240px;border:1px solid rgba(185,154,114,.12);border-radius:50%}
-.hero h1{font-size:clamp(42px,6vw,80px);line-height:1.02;margin:18px 0 16px}
-.hero .sub{font-size:19px;color:var(--taupe);max-width:660px;margin-bottom:30px}
-.btn{display:inline-block;background:var(--green);color:var(--ivory);text-decoration:none;font-weight:600;font-size:16px;padding:16px 32px;border-radius:16px;box-shadow:0 8px 24px rgba(14,143,75,.18);transition:.2s;border:none;cursor:pointer;font-family:'Manrope'}
-.btn:hover{background:var(--green-h)}
-.stats{display:flex;gap:40px;margin-top:42px;flex-wrap:wrap;font-variant-numeric:tabular-nums}
-.stats b{display:block;font-family:'Cormorant Garamond',serif;font-size:36px;color:var(--ivory);font-weight:600}
-.stats .oax{color:var(--orange)}
-.stats span{font-size:12.5px;color:var(--tech);letter-spacing:.06em}
+.hero{position:relative;padding:112px 0 86px;overflow:hidden}
+.hero::before{content:"";position:absolute;right:-170px;top:-140px;width:540px;height:540px;border:1px solid var(--line);border-radius:50%;opacity:.6;pointer-events:none}
+.hero .wrap{position:relative}
+.hero h1{font-size:clamp(44px,6.4vw,82px);line-height:1.02;margin:24px 0 22px;max-width:900px}
+.hero .sub{font-size:19.5px;color:var(--ink-2);max-width:700px;margin-bottom:34px}
+.hero .note{font-size:16px;margin-top:-20px;max-width:660px}
+.hero-compact{padding:76px 0 48px}
+.hero-compact h1{font-size:clamp(34px,4.6vw,58px)}
+.btn{display:inline-block;background:var(--plum);color:#FCFAF6;text-decoration:none;font-family:var(--sans);font-weight:600;font-size:16px;padding:15px 30px;border-radius:10px;border:none;cursor:pointer;transition:background .18s,box-shadow .18s}
+.btn:hover{background:var(--plum-deep);box-shadow:0 6px 18px rgba(118,83,108,.18)}
 
-/* TIMELINE */
-.tl{position:relative;margin-left:12px}
-.tl::before{content:"";position:absolute;left:7px;top:6px;bottom:6px;width:1px;background:linear-gradient(var(--champ2),var(--line))}
-.tl-item{position:relative;padding:0 0 32px 42px}
-.tl-item::before{content:"";position:absolute;left:0;top:8px;width:15px;height:15px;border-radius:50%;background:var(--bg);border:2px solid var(--champ)}
-.tl-item.me::before{background:var(--green);border-color:var(--mint)}
-.tl-gen{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--tech);font-weight:600}
-.tl-item h3{font-size:26px;margin:4px 0 2px}
-.tl-item .yrs{color:var(--champ);font-size:15px;font-weight:500}
-.tl-item p{color:var(--taupe);font-size:15px;max-width:660px;margin-top:6px}
+/* СТАТИСТИКА — крупные цифры под тонкой линейкой, без дашбордных плашек */
+.stats{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:30px 40px;margin-top:56px;padding-top:28px;border-top:1px solid var(--line);font-variant-numeric:tabular-nums}
+.stats b{display:block;font-family:var(--serif);font-size:clamp(38px,4.6vw,56px);line-height:1;font-weight:500;color:var(--ink)}
+.stats span{display:block;margin-top:12px;font-size:11.5px;line-height:1.5;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-3);font-weight:500}
 
-/* GRID/CARDS */
-.grid{display:grid;gap:22px}
-.g2{grid-template-columns:1fr 1fr}
-.g3{grid-template-columns:1fr 1fr 1fr}
-.card{background:var(--card-soft);border:1px solid var(--border);border-radius:22px;padding:28px;transition:.25s}
-.card:hover{border-color:var(--champ2);background:var(--card)}
-.card h3{font-size:25px;margin-bottom:4px}
-.card h4{font-size:21px;margin-bottom:4px}
-.card .tag{font-size:12px;color:var(--champ);letter-spacing:.12em;text-transform:uppercase;font-weight:600}
-.card p{font-size:15px;color:var(--taupe);margin-top:8px}
-.card p b{color:var(--pearl);font-weight:600}
-.card .mini{font-size:13px;color:var(--tech);margin-top:12px;border-top:1px solid var(--line);padding-top:10px}
-.gip{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--champ2);border:1px solid var(--line);border-radius:7px;padding:1px 8px;margin-left:6px;vertical-align:2px}
+/* ЛЕНТА ПОКОЛЕНИЙ */
+.tl{position:relative;padding-left:36px}
+.tl::before{content:"";position:absolute;left:7px;top:12px;bottom:18px;width:1px;background:var(--line-strong)}
+.tl-item{position:relative;padding-bottom:42px}
+.tl-item:last-child{padding-bottom:0}
+.tl-item::before{content:"";position:absolute;left:-36px;top:9px;width:15px;height:15px;border-radius:50%;background:var(--surface);border:1.5px solid var(--olive)}
+.tl-item.me::before{background:var(--plum);border-color:var(--plum)}
+.tl-gen{font-size:11.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--ink-3);font-weight:600}
+.tl-item h3{font-size:29px;line-height:1.14;margin:8px 0 3px}
+.tl-item .yrs{color:var(--plum);font-size:15.5px;font-weight:500;font-variant-numeric:tabular-nums}
+.tl-item p{color:var(--ink-2);font-size:16px;max-width:660px;margin-top:9px}
 
-/* WAR */
-.wcard{display:flex;gap:20px;background:var(--card-soft);border:1px solid var(--border);border-radius:22px;padding:20px;transition:.25s}
-.wcard:hover{border-color:var(--champ2)}
-.wcard img{width:112px;height:112px;object-fit:cover;border-radius:14px;border:1px solid var(--champ2);flex-shrink:0;filter:sepia(.14)}
-.wcard h3{font-size:21px;line-height:1.12}
-.wcard .yrs{color:var(--champ);font-size:14px}
-.wcard p{font-size:13.5px;color:var(--taupe);margin-top:6px}
-.orange{color:var(--orange-t);font-weight:600}
+/* КАРТОЧКИ */
+.grid{display:grid;gap:24px}
+.g2{grid-template-columns:repeat(2,minmax(0,1fr))}
+.g3{grid-template-columns:repeat(3,minmax(0,1fr))}
+.card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:30px;transition:border-color .2s,box-shadow .2s}
+.card:hover{border-color:var(--line-strong);box-shadow:var(--shadow)}
+.card h3{font-size:28px;line-height:1.14;margin-bottom:6px}
+.card h4{font-size:23px;line-height:1.2;margin-bottom:6px}
+.card .tag{display:block;font-size:11.5px;letter-spacing:.15em;text-transform:uppercase;color:var(--olive-ink);font-weight:600;margin-bottom:14px}
+.card p{font-size:16px;color:var(--ink-2);margin-top:12px}
+.card .mini{font-size:13.5px;color:var(--ink-3);margin-top:22px;padding-top:14px;border-top:1px solid var(--line-soft)}
+.gip{display:inline-block;font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--plum);background:var(--plum-tint);border-radius:6px;padding:2px 8px;margin-left:6px;vertical-align:2px}
 
-/* ROUTES */
-.route{display:flex;align-items:flex-start;gap:16px;padding:20px 0;border-bottom:1px solid var(--line)}
+/* ФОТОГРАФИИ — архивные врезки: тонкая рамка, светлое паспарту, сухая подпись */
+.strip{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px}
+.ph{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:12px}
+.ph img{width:100%;height:250px;object-fit:cover;display:block;border-radius:6px}
+.ph figcaption{padding:14px 4px 2px;font-size:13.5px;line-height:1.5;color:var(--ink-3)}
+.wcard{display:flex;gap:22px;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:22px;transition:border-color .2s,box-shadow .2s}
+.wcard:hover{border-color:var(--line-strong);box-shadow:var(--shadow)}
+.wcard img{width:116px;height:116px;object-fit:cover;border-radius:8px;border:1px solid var(--line);flex-shrink:0}
+.wcard h3{font-size:23px;line-height:1.14}
+.wcard .yrs{color:var(--plum);font-size:14.5px}
+.wcard p{font-size:15px;color:var(--ink-2);margin-top:8px}
+
+/* ПЕРЕМЕЩЕНИЯ */
+.route{display:flex;align-items:flex-start;gap:18px;padding:22px 0;border-bottom:1px solid var(--line-soft)}
 .route:last-child{border-bottom:none}
-.route .from{min-width:230px}
-.route .arrow{color:var(--champ);font-size:20px;padding-top:2px}
-.route b{color:var(--ivory);font-weight:600;font-size:16px}
-.route span{display:block;font-size:13.5px;color:var(--tech);margin-top:3px}
+.route .from{min-width:240px}
+.route .arrow{color:var(--olive);font-size:20px;padding-top:2px}
+.route b{font-size:16.5px}
+.route span{display:block;font-size:14px;color:var(--ink-3);margin-top:4px}
 
-/* PHOTO STRIP */
-.strip{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
-.ph{background:var(--card-soft);border:1px solid var(--border);border-radius:20px;overflow:hidden}
-.ph img{width:100%;height:240px;object-fit:cover;display:block;filter:sepia(.12)}
-.ph figcaption{padding:13px 17px;font-size:13.5px;color:var(--taupe)}
-
-/* SOURCES (light) */
-.src{background:#F5F0EA}
-.src h2,.src h3{color:var(--bg2)}
-.src .label{color:#C0501C}
-.src p,.src li{color:#5a4450;font-size:15px}
-.src .scard{background:#EFE7DE;border:1px solid #d9cabc;border-radius:20px;padding:26px}
-.src .scard h3{font-size:22px;margin-bottom:10px}
+/* ИСТОЧНИКИ — светлая вкладка внутри страницы */
+.src{background:var(--surface);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+.src .scard{background:var(--paper);border:1px solid var(--line);border-radius:var(--radius);padding:30px}
+.src .scard h3{font-size:24px;line-height:1.18;margin-bottom:14px}
+.src p,.src li{color:var(--ink-2);font-size:16px}
 .src ul{list-style:none}
-.src li{padding:7px 0;border-bottom:1px solid #e2d5c8}
-.src li:last-child{border:none}
-.src b{color:#2A0C1E}
-.leg{display:inline-block;background:#EFE7DE;border:1px solid #B99A72;color:#4A1733;font-weight:700;border-radius:8px;padding:2px 10px;font-size:13px;margin-right:8px}
+.src li{padding:10px 0;border-bottom:1px solid var(--line-soft)}
+.src li:last-child{border-bottom:none}
+.leg{display:inline-block;background:var(--plum-tint);color:var(--plum);font-weight:600;border-radius:6px;padding:2px 9px;font-size:12px;letter-spacing:.07em;text-transform:uppercase;margin-right:8px;vertical-align:1px}
 
-/* ДРЕВО — SVG-родословная */
-.pedigree{width:100%;height:auto;display:block;font-family:'Manrope',sans-serif}
-.pedigree .colhead{font-size:9px;letter-spacing:.14em;fill:var(--champ);font-weight:700}
-.pedigree .ln{stroke:#5B3446;stroke-width:1.2;fill:none}
-.pedigree .bx rect{fill:rgba(58,16,40,.9);stroke:#5B3446;stroke-width:1}
-.pedigree .bx:hover rect{fill:#3A1028;stroke:var(--champ2)}
-.pedigree .bx.q rect{fill:rgba(19,6,13,.35);stroke:#4A2A39;stroke-dasharray:4 3}
-.pedigree .bx.me rect{fill:rgba(14,143,75,.12);stroke:var(--green);stroke-width:1.4}
-.pedigree .bx.deep rect{stroke:var(--champ);stroke-width:1.2}
-.pedigree .bx.hyp rect{fill:rgba(58,16,40,.55);stroke:var(--champ2);stroke-dasharray:5 3}
-.pedigree .bx.hyp .t3{fill:var(--orange-t)}
-.pedigree .t1{font-size:11.5px;font-weight:700;fill:var(--ivory)}
-.pedigree .t2{font-size:10.5px;fill:var(--pearl)}
-.pedigree .t3{font-size:9.5px;fill:var(--champ)}
-.pedigree .t3.or{fill:var(--orange);font-weight:700}
-.pedigree .bx.q .t1,.pedigree .bx.q .t2{fill:var(--tech)}
-.pedigree .bx.q .t3{fill:var(--orange-t);font-weight:600}
-.pedigree .bx.me .t1{fill:var(--ivory)}
-.legend{display:flex;gap:22px;flex-wrap:wrap;margin-top:18px;font-size:13px;color:var(--taupe)}
-.legend i{display:inline-block;width:14px;height:14px;border-radius:4px;margin-right:6px;vertical-align:-2px}
+/* ДРЕВО — статус данных кодируется цветом рамки и бейджем */
+.treewrap{overflow-x:auto;padding-top:26px;-webkit-overflow-scrolling:touch;scrollbar-width:thin;scrollbar-color:var(--line-strong) var(--paper-deep)}
+.treewrap::-webkit-scrollbar{height:10px}
+.treewrap::-webkit-scrollbar-track{background:var(--paper-deep);border-radius:5px}
+.treewrap::-webkit-scrollbar-thumb{background:var(--line-strong);border-radius:5px}
+.pedigree{width:100%;height:auto;display:block;font-family:var(--sans)}
+.pedigree .colhead{font-size:10.5px;letter-spacing:.16em;font-weight:600;fill:var(--ink-3)}
+.pedigree .ln{stroke:var(--line-strong);stroke-width:1.1;fill:none}
+.pedigree .fr{fill:var(--surface);stroke:var(--line-strong);stroke-width:1.1;filter:drop-shadow(0 1px 1.5px rgba(37,35,33,.06))}
+.pedigree .t1{font-size:13px;font-weight:600;fill:var(--ink)}
+.pedigree .t2{font-size:11px;fill:var(--ink)}
+.pedigree .t3{font-size:10.5px;fill:var(--ink-3);font-variant-numeric:tabular-nums}
+.pedigree .bdg{font-size:9px;font-weight:600;letter-spacing:.08em;text-transform:uppercase}
+.pedigree .bg{stroke:none}
+.pedigree .bx{transition:opacity .15s}
+/* Подтверждено — серо-оливковый */
+.pedigree .bx.ok .fr{stroke:var(--olive)}
+.pedigree .bx.ok .bg{fill:var(--olive-tint)}
+.pedigree .bx.ok .bdg{fill:var(--olive-ink)}
+/* Гипотеза — сливовый */
+.pedigree .bx.hyp .fr{stroke:var(--plum)}
+.pedigree .bx.hyp .bg{fill:var(--plum-tint)}
+.pedigree .bx.hyp .bdg{fill:var(--plum)}
+/* Нет данных — светло-серый пунктир, без подложки и тени */
+.pedigree .bx.q .fr{fill:none;stroke:var(--line-strong);stroke-width:1;stroke-dasharray:5 4;filter:none}
+.pedigree .bx.q .t1,.pedigree .bx.q .t2{fill:var(--ink-2)}
+.pedigree .bx.q .bg{fill:rgba(37,35,33,.05)}
+.pedigree .bx.q .bdg{fill:var(--ink-3)}
+/* Край прослеженной линии — та же палитра, только плотнее рамка */
+.pedigree .bx.deep .fr{stroke-width:1.6}
+/* Семья, от которой ведётся отсчёт */
+.pedigree .bx.me .fr{fill:var(--paper-deep)}
+.pedigree .bx.me .t1{font-weight:700}
+.legend{display:flex;flex-wrap:wrap;gap:14px 30px;margin-top:26px;font-size:14px;color:var(--ink-2)}
+.legend span{display:inline-flex;align-items:center;gap:9px}
+.legend i{width:15px;height:15px;border-radius:4px;flex-shrink:0}
+.legend i.ok{background:var(--olive-tint);border:1px solid var(--olive)}
+.legend i.hyp{background:var(--plum-tint);border:1px solid var(--plum)}
+.legend i.q{border:1px dashed var(--line-strong)}
+.legend i.anchor{background:var(--paper-deep);border:1px solid var(--ink)}
 
-/* SEARCH MAP */
-.goalrow{display:flex;gap:14px;align-items:flex-start;padding:16px 0;border-bottom:1px solid var(--line)}
+/* КАРТА ПОИСКА */
+.goalrow{display:flex;align-items:flex-start;gap:18px;padding:20px 0;border-bottom:1px solid var(--line)}
 .goalrow:last-child{border-bottom:none}
-.goalrow .n{font-family:'Cormorant Garamond',serif;font-size:26px;color:var(--champ);min-width:34px;font-weight:600}
-.goalrow b{color:var(--ivory);font-weight:600}
-.goalrow p{font-size:14px;color:var(--taupe);margin-top:3px}
-.goalrow .st{font-size:12px;margin-top:4px;color:var(--mint);font-weight:600}
+.goalrow .n{font-family:var(--serif);font-size:30px;line-height:1;font-weight:500;color:var(--plum);min-width:36px;padding-top:3px;font-variant-numeric:tabular-nums}
+.goalrow b{font-size:16.5px}
+.goalrow p{font-size:15px;color:var(--ink-2);margin-top:5px}
+.goalrow .st{font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--olive-ink);font-weight:600;margin-top:9px}
 
-footer{padding:48px 0;border-top:1px solid var(--line);color:var(--tech);font-size:13.5px}
-footer b{color:var(--champ)}
-@media(max-width:900px){.g2,.g3,.strip{grid-template-columns:1fr}section{padding:56px 0}.route .from{min-width:150px}}
-@media(max-width:600px){
-  body{font-size:16px}
-  .wrap{padding:0 18px}
-  nav .wrap{gap:6px;padding-top:10px;padding-bottom:10px}
-  nav .brand{font-size:15px;line-height:1.15;max-width:34%}
-  .navbtn{padding:8px 12px;font-size:13px}
-  .hero{padding:56px 0 44px}
-  .stats{gap:22px 28px}
-  .stats b{font-size:30px}
-  .card{padding:22px}
-  .goalrow .n{font-size:22px;min-width:26px}
+footer{padding:56px 0 64px;border-top:1px solid var(--line);color:var(--ink-3);font-size:14px}
+footer b{color:var(--ink)}
+
+@media(max-width:980px){
+  .g2,.g3,.strip{grid-template-columns:1fr}
+  section{padding:70px 0}
+  .stats{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .route .from{min-width:160px}
 }
-
+@media(max-width:600px){
+  body{font-size:17px}
+  .wrap{padding:0 20px}
+  section{padding:56px 0}
+  nav .wrap{gap:4px;padding-top:12px;padding-bottom:12px}
+  nav .brand{font-size:16px;line-height:1.15;max-width:38%}
+  .navbtn{padding:8px 12px;font-size:13.5px}
+  .hero{padding:60px 0 52px}
+  .hero::before{display:none}
+  .hero h1{margin:18px 0 18px}
+  .hero .sub{font-size:18px}
+  .hero .note{font-size:15.5px;margin-top:-14px}
+  .hero-compact{padding:48px 0 36px}
+  .sect-head{margin-bottom:38px}
+  .sect-head p{font-size:16px}
+  .stats{gap:24px 22px;margin-top:38px;padding-top:22px}
+  .stats b{font-size:38px}
+  .stats span{font-size:11px;margin-top:9px}
+  .card{padding:24px}
+  .card h3{font-size:25px}
+  .src .scard{padding:24px}
+  .tl-item h3{font-size:25px}
+  .goalrow .n{font-size:25px;min-width:28px}
+  .wcard{flex-direction:column}
+  .legend{gap:12px 20px;font-size:13.5px}
+}

--- a/index.html
+++ b/index.html
@@ -4,156 +4,219 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Род Матюхиных и Скиба — семейный архив</title>
-<style>@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Manrope:wght@300;400;500;600;700&display=swap');
+<style>@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@400;500;600;700&display=swap');
+
+/* Светлый цифровой семейный архив в редакционной эстетике:
+   молочная бумага, тонкие линии, сливовый и серо-оливковый акценты.
+   Никаких тёмных плашек, градиентов и имитации пергамента. */
 :root{
-  --bg:#13060D; --bg2:#2A0C1E; --card:#3A1028; --card-soft:rgba(58,16,40,.72);
-  --ivory:#F3EDE7; --pearl:#DDD3CB; --taupe:#B9AAA2; --tech:#907983;
-  --champ:#D2B48C; --champ2:#B99A72;
-  --green:#0E8F4B; --green-h:#0A6E3A; --mint:#39C270;
-  --line:#4A2A39; --border:#5B3446; --orange:#D2622F; --orange-t:#E08A5E;
+  --paper:#F4F0E8;
+  --paper-deep:#EDE8DE;
+  --surface:#FCFAF6;
+  --ink:#252321;
+  --ink-2:#756F68;
+  /* Мелкий текст (12–14 px) затемнён относительно --ink-2:
+     на молочном фоне вторичный тон иначе не добирает контраста. */
+  --ink-3:#5C574F;
+  --plum:#76536C;
+  --plum-deep:#5D4155;
+  --plum-tint:rgba(118,83,108,.09);
+  --olive:#7B806C;
+  --olive-ink:#5C6150;
+  --olive-tint:rgba(123,128,108,.14);
+  --line:#D8D0C5;
+  --line-soft:#E7E1D6;
+  --line-strong:#C4BAAB;
+  --serif:'Cormorant Garamond',Georgia,'Times New Roman',serif;
+  --sans:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;
+  --shadow:0 1px 2px rgba(37,35,33,.03),0 10px 28px rgba(37,35,33,.05);
+  --radius:14px;
 }
 *{margin:0;padding:0;box-sizing:border-box}
-html{scroll-behavior:smooth}
-body{background:var(--bg);color:var(--pearl);font-family:'Manrope',system-ui,sans-serif;font-size:17px;line-height:1.55;overflow-x:hidden}
-h1,h2,h3,h4{font-family:'Cormorant Garamond',Georgia,serif;color:var(--ivory);font-weight:500}
-.wrap{max-width:1180px;margin:0 auto;padding:0 32px}
-.label{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--champ);font-weight:600}
-section{padding:80px 0}
-.sect-head{margin-bottom:46px}
-.sect-head h2{font-size:clamp(30px,4vw,50px);margin-top:12px}
-.sect-head p{color:var(--taupe);max-width:780px;margin-top:12px}
-.hr{height:1px;background:linear-gradient(90deg,var(--champ2),transparent);width:120px;margin-top:20px;opacity:.6}
+html{scroll-behavior:smooth;-webkit-text-size-adjust:100%}
+body{background:var(--paper);color:var(--ink);font-family:var(--sans);font-size:18px;line-height:1.62;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+h1,h2,h3,h4{font-family:var(--serif);color:var(--ink);font-weight:500;letter-spacing:-.005em}
+b,strong{font-weight:600;color:var(--ink)}
+:focus-visible{outline:2px solid var(--plum);outline-offset:3px;border-radius:4px}
+.wrap{max-width:1120px;margin:0 auto;padding:0 34px}
+section{padding:96px 0}
+.alt{background:var(--paper-deep)}
 .numtab{font-variant-numeric:tabular-nums}
 
+/* Надзаголовок с короткой линейкой — единственный постоянный декоративный элемент */
+.label{display:inline-flex;align-items:center;gap:11px;font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--plum);font-weight:600;line-height:1.4}
+.label::before{content:"";width:26px;height:1px;background:var(--plum);opacity:.5;flex-shrink:0}
+.sect-head{margin-bottom:54px;max-width:840px}
+.sect-head h2{font-size:clamp(32px,4.4vw,52px);line-height:1.08;margin-top:18px}
+.sect-head p{color:var(--ink-2);margin-top:18px;font-size:17px}
+.hr{height:1px;background:var(--line);width:180px;margin-top:28px}
+
 /* NAV */
-nav{position:sticky;top:0;z-index:50;background:rgba(19,6,13,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
-nav .wrap{display:flex;align-items:center;gap:10px;padding-top:14px;padding-bottom:14px}
-nav .brand{font-family:'Cormorant Garamond',serif;font-size:20px;color:var(--ivory);margin-right:auto;font-weight:600}
-.navbtn{background:none;border:1px solid transparent;color:var(--taupe);font-family:'Manrope';font-size:14px;font-weight:600;padding:10px 20px;border-radius:12px;cursor:pointer;transition:.2s}
-.navbtn:hover{color:var(--ivory)}
-.navbtn.active{background:var(--green);color:var(--ivory)}
+nav{position:sticky;top:0;z-index:50;background:rgba(244,240,232,.93);backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+nav .wrap{display:flex;align-items:center;gap:8px;padding-top:16px;padding-bottom:16px}
+nav .brand{font-family:var(--serif);font-size:21px;font-weight:600;color:var(--ink);margin-right:auto}
+.navbtn{background:none;border:none;color:var(--ink-2);font-family:var(--sans);font-size:14.5px;font-weight:500;padding:9px 18px;border-radius:10px;cursor:pointer;transition:color .18s,background .18s}
+.navbtn:hover{color:var(--ink);background:rgba(37,35,33,.04)}
+.navbtn.active{background:var(--plum-tint);color:var(--plum);font-weight:600}
 .page{display:none}
 .page.visible{display:block}
 
 /* HERO */
-.hero{padding:90px 0 66px;background:radial-gradient(circle at 20% 30%, #3A1028 0%, #2A0C1E 35%, #13060D 80%);position:relative;overflow:hidden}
-.hero::before{content:"";position:absolute;right:-140px;top:-140px;width:520px;height:520px;border:1px solid rgba(185,154,114,.18);border-radius:50%}
-.hero::after{content:"";position:absolute;right:80px;top:160px;width:240px;height:240px;border:1px solid rgba(185,154,114,.12);border-radius:50%}
-.hero h1{font-size:clamp(42px,6vw,80px);line-height:1.02;margin:18px 0 16px}
-.hero .sub{font-size:19px;color:var(--taupe);max-width:660px;margin-bottom:30px}
-.btn{display:inline-block;background:var(--green);color:var(--ivory);text-decoration:none;font-weight:600;font-size:16px;padding:16px 32px;border-radius:16px;box-shadow:0 8px 24px rgba(14,143,75,.18);transition:.2s;border:none;cursor:pointer;font-family:'Manrope'}
-.btn:hover{background:var(--green-h)}
-.stats{display:flex;gap:40px;margin-top:42px;flex-wrap:wrap;font-variant-numeric:tabular-nums}
-.stats b{display:block;font-family:'Cormorant Garamond',serif;font-size:36px;color:var(--ivory);font-weight:600}
-.stats .oax{color:var(--orange)}
-.stats span{font-size:12.5px;color:var(--tech);letter-spacing:.06em}
+.hero{position:relative;padding:112px 0 86px;overflow:hidden}
+.hero::before{content:"";position:absolute;right:-170px;top:-140px;width:540px;height:540px;border:1px solid var(--line);border-radius:50%;opacity:.6;pointer-events:none}
+.hero .wrap{position:relative}
+.hero h1{font-size:clamp(44px,6.4vw,82px);line-height:1.02;margin:24px 0 22px;max-width:900px}
+.hero .sub{font-size:19.5px;color:var(--ink-2);max-width:700px;margin-bottom:34px}
+.hero .note{font-size:16px;margin-top:-20px;max-width:660px}
+.hero-compact{padding:76px 0 48px}
+.hero-compact h1{font-size:clamp(34px,4.6vw,58px)}
+.btn{display:inline-block;background:var(--plum);color:#FCFAF6;text-decoration:none;font-family:var(--sans);font-weight:600;font-size:16px;padding:15px 30px;border-radius:10px;border:none;cursor:pointer;transition:background .18s,box-shadow .18s}
+.btn:hover{background:var(--plum-deep);box-shadow:0 6px 18px rgba(118,83,108,.18)}
 
-/* TIMELINE */
-.tl{position:relative;margin-left:12px}
-.tl::before{content:"";position:absolute;left:7px;top:6px;bottom:6px;width:1px;background:linear-gradient(var(--champ2),var(--line))}
-.tl-item{position:relative;padding:0 0 32px 42px}
-.tl-item::before{content:"";position:absolute;left:0;top:8px;width:15px;height:15px;border-radius:50%;background:var(--bg);border:2px solid var(--champ)}
-.tl-item.me::before{background:var(--green);border-color:var(--mint)}
-.tl-gen{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--tech);font-weight:600}
-.tl-item h3{font-size:26px;margin:4px 0 2px}
-.tl-item .yrs{color:var(--champ);font-size:15px;font-weight:500}
-.tl-item p{color:var(--taupe);font-size:15px;max-width:660px;margin-top:6px}
+/* СТАТИСТИКА — крупные цифры под тонкой линейкой, без дашбордных плашек */
+.stats{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:30px 40px;margin-top:56px;padding-top:28px;border-top:1px solid var(--line);font-variant-numeric:tabular-nums}
+.stats b{display:block;font-family:var(--serif);font-size:clamp(38px,4.6vw,56px);line-height:1;font-weight:500;color:var(--ink)}
+.stats span{display:block;margin-top:12px;font-size:11.5px;line-height:1.5;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-3);font-weight:500}
 
-/* GRID/CARDS */
-.grid{display:grid;gap:22px}
-.g2{grid-template-columns:1fr 1fr}
-.g3{grid-template-columns:1fr 1fr 1fr}
-.card{background:var(--card-soft);border:1px solid var(--border);border-radius:22px;padding:28px;transition:.25s}
-.card:hover{border-color:var(--champ2);background:var(--card)}
-.card h3{font-size:25px;margin-bottom:4px}
-.card h4{font-size:21px;margin-bottom:4px}
-.card .tag{font-size:12px;color:var(--champ);letter-spacing:.12em;text-transform:uppercase;font-weight:600}
-.card p{font-size:15px;color:var(--taupe);margin-top:8px}
-.card p b{color:var(--pearl);font-weight:600}
-.card .mini{font-size:13px;color:var(--tech);margin-top:12px;border-top:1px solid var(--line);padding-top:10px}
-.gip{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--champ2);border:1px solid var(--line);border-radius:7px;padding:1px 8px;margin-left:6px;vertical-align:2px}
+/* ЛЕНТА ПОКОЛЕНИЙ */
+.tl{position:relative;padding-left:36px}
+.tl::before{content:"";position:absolute;left:7px;top:12px;bottom:18px;width:1px;background:var(--line-strong)}
+.tl-item{position:relative;padding-bottom:42px}
+.tl-item:last-child{padding-bottom:0}
+.tl-item::before{content:"";position:absolute;left:-36px;top:9px;width:15px;height:15px;border-radius:50%;background:var(--surface);border:1.5px solid var(--olive)}
+.tl-item.me::before{background:var(--plum);border-color:var(--plum)}
+.tl-gen{font-size:11.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--ink-3);font-weight:600}
+.tl-item h3{font-size:29px;line-height:1.14;margin:8px 0 3px}
+.tl-item .yrs{color:var(--plum);font-size:15.5px;font-weight:500;font-variant-numeric:tabular-nums}
+.tl-item p{color:var(--ink-2);font-size:16px;max-width:660px;margin-top:9px}
 
-/* WAR */
-.wcard{display:flex;gap:20px;background:var(--card-soft);border:1px solid var(--border);border-radius:22px;padding:20px;transition:.25s}
-.wcard:hover{border-color:var(--champ2)}
-.wcard img{width:112px;height:112px;object-fit:cover;border-radius:14px;border:1px solid var(--champ2);flex-shrink:0;filter:sepia(.14)}
-.wcard h3{font-size:21px;line-height:1.12}
-.wcard .yrs{color:var(--champ);font-size:14px}
-.wcard p{font-size:13.5px;color:var(--taupe);margin-top:6px}
-.orange{color:var(--orange-t);font-weight:600}
+/* КАРТОЧКИ */
+.grid{display:grid;gap:24px}
+.g2{grid-template-columns:repeat(2,minmax(0,1fr))}
+.g3{grid-template-columns:repeat(3,minmax(0,1fr))}
+.card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:30px;transition:border-color .2s,box-shadow .2s}
+.card:hover{border-color:var(--line-strong);box-shadow:var(--shadow)}
+.card h3{font-size:28px;line-height:1.14;margin-bottom:6px}
+.card h4{font-size:23px;line-height:1.2;margin-bottom:6px}
+.card .tag{display:block;font-size:11.5px;letter-spacing:.15em;text-transform:uppercase;color:var(--olive-ink);font-weight:600;margin-bottom:14px}
+.card p{font-size:16px;color:var(--ink-2);margin-top:12px}
+.card .mini{font-size:13.5px;color:var(--ink-3);margin-top:22px;padding-top:14px;border-top:1px solid var(--line-soft)}
+.gip{display:inline-block;font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--plum);background:var(--plum-tint);border-radius:6px;padding:2px 8px;margin-left:6px;vertical-align:2px}
 
-/* ROUTES */
-.route{display:flex;align-items:flex-start;gap:16px;padding:20px 0;border-bottom:1px solid var(--line)}
+/* ФОТОГРАФИИ — архивные врезки: тонкая рамка, светлое паспарту, сухая подпись */
+.strip{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px}
+.ph{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:12px}
+.ph img{width:100%;height:250px;object-fit:cover;display:block;border-radius:6px}
+.ph figcaption{padding:14px 4px 2px;font-size:13.5px;line-height:1.5;color:var(--ink-3)}
+.wcard{display:flex;gap:22px;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:22px;transition:border-color .2s,box-shadow .2s}
+.wcard:hover{border-color:var(--line-strong);box-shadow:var(--shadow)}
+.wcard img{width:116px;height:116px;object-fit:cover;border-radius:8px;border:1px solid var(--line);flex-shrink:0}
+.wcard h3{font-size:23px;line-height:1.14}
+.wcard .yrs{color:var(--plum);font-size:14.5px}
+.wcard p{font-size:15px;color:var(--ink-2);margin-top:8px}
+
+/* ПЕРЕМЕЩЕНИЯ */
+.route{display:flex;align-items:flex-start;gap:18px;padding:22px 0;border-bottom:1px solid var(--line-soft)}
 .route:last-child{border-bottom:none}
-.route .from{min-width:230px}
-.route .arrow{color:var(--champ);font-size:20px;padding-top:2px}
-.route b{color:var(--ivory);font-weight:600;font-size:16px}
-.route span{display:block;font-size:13.5px;color:var(--tech);margin-top:3px}
+.route .from{min-width:240px}
+.route .arrow{color:var(--olive);font-size:20px;padding-top:2px}
+.route b{font-size:16.5px}
+.route span{display:block;font-size:14px;color:var(--ink-3);margin-top:4px}
 
-/* PHOTO STRIP */
-.strip{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
-.ph{background:var(--card-soft);border:1px solid var(--border);border-radius:20px;overflow:hidden}
-.ph img{width:100%;height:240px;object-fit:cover;display:block;filter:sepia(.12)}
-.ph figcaption{padding:13px 17px;font-size:13.5px;color:var(--taupe)}
-
-/* SOURCES (light) */
-.src{background:#F5F0EA}
-.src h2,.src h3{color:var(--bg2)}
-.src .label{color:#C0501C}
-.src p,.src li{color:#5a4450;font-size:15px}
-.src .scard{background:#EFE7DE;border:1px solid #d9cabc;border-radius:20px;padding:26px}
-.src .scard h3{font-size:22px;margin-bottom:10px}
+/* ИСТОЧНИКИ — светлая вкладка внутри страницы */
+.src{background:var(--surface);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+.src .scard{background:var(--paper);border:1px solid var(--line);border-radius:var(--radius);padding:30px}
+.src .scard h3{font-size:24px;line-height:1.18;margin-bottom:14px}
+.src p,.src li{color:var(--ink-2);font-size:16px}
 .src ul{list-style:none}
-.src li{padding:7px 0;border-bottom:1px solid #e2d5c8}
-.src li:last-child{border:none}
-.src b{color:#2A0C1E}
-.leg{display:inline-block;background:#EFE7DE;border:1px solid #B99A72;color:#4A1733;font-weight:700;border-radius:8px;padding:2px 10px;font-size:13px;margin-right:8px}
+.src li{padding:10px 0;border-bottom:1px solid var(--line-soft)}
+.src li:last-child{border-bottom:none}
+.leg{display:inline-block;background:var(--plum-tint);color:var(--plum);font-weight:600;border-radius:6px;padding:2px 9px;font-size:12px;letter-spacing:.07em;text-transform:uppercase;margin-right:8px;vertical-align:1px}
 
-/* ДРЕВО — SVG-родословная */
-.pedigree{width:100%;height:auto;display:block;font-family:'Manrope',sans-serif}
-.pedigree .colhead{font-size:9px;letter-spacing:.14em;fill:var(--champ);font-weight:700}
-.pedigree .ln{stroke:#5B3446;stroke-width:1.2;fill:none}
-.pedigree .bx rect{fill:rgba(58,16,40,.9);stroke:#5B3446;stroke-width:1}
-.pedigree .bx:hover rect{fill:#3A1028;stroke:var(--champ2)}
-.pedigree .bx.q rect{fill:rgba(19,6,13,.35);stroke:#4A2A39;stroke-dasharray:4 3}
-.pedigree .bx.me rect{fill:rgba(14,143,75,.12);stroke:var(--green);stroke-width:1.4}
-.pedigree .bx.deep rect{stroke:var(--champ);stroke-width:1.2}
-.pedigree .bx.hyp rect{fill:rgba(58,16,40,.55);stroke:var(--champ2);stroke-dasharray:5 3}
-.pedigree .bx.hyp .t3{fill:var(--orange-t)}
-.pedigree .t1{font-size:11.5px;font-weight:700;fill:var(--ivory)}
-.pedigree .t2{font-size:10.5px;fill:var(--pearl)}
-.pedigree .t3{font-size:9.5px;fill:var(--champ)}
-.pedigree .t3.or{fill:var(--orange);font-weight:700}
-.pedigree .bx.q .t1,.pedigree .bx.q .t2{fill:var(--tech)}
-.pedigree .bx.q .t3{fill:var(--orange-t);font-weight:600}
-.pedigree .bx.me .t1{fill:var(--ivory)}
-.legend{display:flex;gap:22px;flex-wrap:wrap;margin-top:18px;font-size:13px;color:var(--taupe)}
-.legend i{display:inline-block;width:14px;height:14px;border-radius:4px;margin-right:6px;vertical-align:-2px}
+/* ДРЕВО — статус данных кодируется цветом рамки и бейджем */
+.treewrap{overflow-x:auto;padding-top:26px;-webkit-overflow-scrolling:touch;scrollbar-width:thin;scrollbar-color:var(--line-strong) var(--paper-deep)}
+.treewrap::-webkit-scrollbar{height:10px}
+.treewrap::-webkit-scrollbar-track{background:var(--paper-deep);border-radius:5px}
+.treewrap::-webkit-scrollbar-thumb{background:var(--line-strong);border-radius:5px}
+.pedigree{width:100%;height:auto;display:block;font-family:var(--sans)}
+.pedigree .colhead{font-size:10.5px;letter-spacing:.16em;font-weight:600;fill:var(--ink-3)}
+.pedigree .ln{stroke:var(--line-strong);stroke-width:1.1;fill:none}
+.pedigree .fr{fill:var(--surface);stroke:var(--line-strong);stroke-width:1.1;filter:drop-shadow(0 1px 1.5px rgba(37,35,33,.06))}
+.pedigree .t1{font-size:13px;font-weight:600;fill:var(--ink)}
+.pedigree .t2{font-size:11px;fill:var(--ink)}
+.pedigree .t3{font-size:10.5px;fill:var(--ink-3);font-variant-numeric:tabular-nums}
+.pedigree .bdg{font-size:9px;font-weight:600;letter-spacing:.08em;text-transform:uppercase}
+.pedigree .bg{stroke:none}
+.pedigree .bx{transition:opacity .15s}
+/* Подтверждено — серо-оливковый */
+.pedigree .bx.ok .fr{stroke:var(--olive)}
+.pedigree .bx.ok .bg{fill:var(--olive-tint)}
+.pedigree .bx.ok .bdg{fill:var(--olive-ink)}
+/* Гипотеза — сливовый */
+.pedigree .bx.hyp .fr{stroke:var(--plum)}
+.pedigree .bx.hyp .bg{fill:var(--plum-tint)}
+.pedigree .bx.hyp .bdg{fill:var(--plum)}
+/* Нет данных — светло-серый пунктир, без подложки и тени */
+.pedigree .bx.q .fr{fill:none;stroke:var(--line-strong);stroke-width:1;stroke-dasharray:5 4;filter:none}
+.pedigree .bx.q .t1,.pedigree .bx.q .t2{fill:var(--ink-2)}
+.pedigree .bx.q .bg{fill:rgba(37,35,33,.05)}
+.pedigree .bx.q .bdg{fill:var(--ink-3)}
+/* Край прослеженной линии — та же палитра, только плотнее рамка */
+.pedigree .bx.deep .fr{stroke-width:1.6}
+/* Семья, от которой ведётся отсчёт */
+.pedigree .bx.me .fr{fill:var(--paper-deep)}
+.pedigree .bx.me .t1{font-weight:700}
+.legend{display:flex;flex-wrap:wrap;gap:14px 30px;margin-top:26px;font-size:14px;color:var(--ink-2)}
+.legend span{display:inline-flex;align-items:center;gap:9px}
+.legend i{width:15px;height:15px;border-radius:4px;flex-shrink:0}
+.legend i.ok{background:var(--olive-tint);border:1px solid var(--olive)}
+.legend i.hyp{background:var(--plum-tint);border:1px solid var(--plum)}
+.legend i.q{border:1px dashed var(--line-strong)}
+.legend i.anchor{background:var(--paper-deep);border:1px solid var(--ink)}
 
-/* SEARCH MAP */
-.goalrow{display:flex;gap:14px;align-items:flex-start;padding:16px 0;border-bottom:1px solid var(--line)}
+/* КАРТА ПОИСКА */
+.goalrow{display:flex;align-items:flex-start;gap:18px;padding:20px 0;border-bottom:1px solid var(--line)}
 .goalrow:last-child{border-bottom:none}
-.goalrow .n{font-family:'Cormorant Garamond',serif;font-size:26px;color:var(--champ);min-width:34px;font-weight:600}
-.goalrow b{color:var(--ivory);font-weight:600}
-.goalrow p{font-size:14px;color:var(--taupe);margin-top:3px}
-.goalrow .st{font-size:12px;margin-top:4px;color:var(--mint);font-weight:600}
+.goalrow .n{font-family:var(--serif);font-size:30px;line-height:1;font-weight:500;color:var(--plum);min-width:36px;padding-top:3px;font-variant-numeric:tabular-nums}
+.goalrow b{font-size:16.5px}
+.goalrow p{font-size:15px;color:var(--ink-2);margin-top:5px}
+.goalrow .st{font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--olive-ink);font-weight:600;margin-top:9px}
 
-footer{padding:48px 0;border-top:1px solid var(--line);color:var(--tech);font-size:13.5px}
-footer b{color:var(--champ)}
-@media(max-width:900px){.g2,.g3,.strip{grid-template-columns:1fr}section{padding:56px 0}.route .from{min-width:150px}}
-@media(max-width:600px){
-  body{font-size:16px}
-  .wrap{padding:0 18px}
-  nav .wrap{gap:6px;padding-top:10px;padding-bottom:10px}
-  nav .brand{font-size:15px;line-height:1.15;max-width:34%}
-  .navbtn{padding:8px 12px;font-size:13px}
-  .hero{padding:56px 0 44px}
-  .stats{gap:22px 28px}
-  .stats b{font-size:30px}
-  .card{padding:22px}
-  .goalrow .n{font-size:22px;min-width:26px}
+footer{padding:56px 0 64px;border-top:1px solid var(--line);color:var(--ink-3);font-size:14px}
+footer b{color:var(--ink)}
+
+@media(max-width:980px){
+  .g2,.g3,.strip{grid-template-columns:1fr}
+  section{padding:70px 0}
+  .stats{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .route .from{min-width:160px}
 }
-
+@media(max-width:600px){
+  body{font-size:17px}
+  .wrap{padding:0 20px}
+  section{padding:56px 0}
+  nav .wrap{gap:4px;padding-top:12px;padding-bottom:12px}
+  nav .brand{font-size:16px;line-height:1.15;max-width:38%}
+  .navbtn{padding:8px 12px;font-size:13.5px}
+  .hero{padding:60px 0 52px}
+  .hero::before{display:none}
+  .hero h1{margin:18px 0 18px}
+  .hero .sub{font-size:18px}
+  .hero .note{font-size:15.5px;margin-top:-14px}
+  .hero-compact{padding:48px 0 36px}
+  .sect-head{margin-bottom:38px}
+  .sect-head p{font-size:16px}
+  .stats{gap:24px 22px;margin-top:38px;padding-top:22px}
+  .stats b{font-size:38px}
+  .stats span{font-size:11px;margin-top:9px}
+  .card{padding:24px}
+  .card h3{font-size:25px}
+  .src .scard{padding:24px}
+  .tl-item h3{font-size:25px}
+  .goalrow .n{font-size:25px;min-width:28px}
+  .wcard{flex-direction:column}
+  .legend{gap:12px 20px;font-size:13.5px}
+}
 </style>
 </head>
 <body>
@@ -171,13 +234,13 @@ footer b{color:var(--champ)}
     <div class="label">Семейный архив · MyHeritage · экспорт 17 июля 2026</div>
     <h1>Летопись рода Матюхиных и Скиба</h1>
     <p class="sub">Две главные линии — <b>Матюхины</b> из села Мокрое Тульской губернии и <b>Скибы</b> с донбасской Лозовой Павловки — сошлись в семье Сергея и Надежды. Тульская земля и Донбасс, Валдай и Татария, Подмосковье; 233 человека в базе, 40 фамилий, 6 поколений прослежено.</p>
-    <p class="sub" style="font-size:15px;margin-top:-14px">Страница собрана автоматически из семейного древа MyHeritage. Точные даты, места рождения и контактные данные ныне живущих не публикуются; указаны только имена и годы рождения.</p>
+    <p class="sub note">Страница собрана автоматически из семейного древа MyHeritage. Точные даты, места рождения и контактные данные ныне живущих не публикуются; указаны только имена и годы рождения.</p>
     <button class="btn" onclick="showPage(2)">Открыть древо</button>
     <div class="stats">
       <div><b>6</b><span>ПОКОЛЕНИЙ ПРОСЛЕЖЕНО</span></div>
       <div><b>233</b><span>ЧЕЛОВЕКА В БАЗЕ</span></div>
       <div><b>40</b><span>РОДОВЫХ ФАМИЛИЙ</span></div>
-      <div><b>1827</b><span>ГОД РОЖДЕНИЯ САМОГО РАННЕГО ПРЕДКА</span></div>
+      <div><b>1827</b><span>САМОЕ РАННЕЕ РОЖДЕНИЕ</span></div>
     </div>
   </div>
 </div>
@@ -253,7 +316,7 @@ footer b{color:var(--champ)}
   </div>
 </section>
 
-<section style="background:var(--bg2)">
+<section class="alt">
   <div class="wrap">
     <div class="sect-head">
       <div class="label">Самая длинная прослеженная линия</div>
@@ -308,7 +371,7 @@ footer b{color:var(--champ)}
   </div>
 </section>
 
-<section style="background:var(--bg2)">
+<section class="alt">
   <div class="wrap">
     <div class="sect-head">
       <div class="label">География</div>
@@ -399,10 +462,10 @@ footer b{color:var(--champ)}
 </div>
 
 <div class="page" id="page2">
-<section class="hero" style="padding:60px 0 40px">
+<section class="hero hero-compact">
   <div class="wrap">
     <div class="label">Страница 2 · визуальное древо · прямые предки</div>
-    <h1 style="font-size:clamp(34px,4vw,56px)">Древо прямых предков</h1>
+    <h1>Древо прямых предков</h1>
     <p class="sub">Читается слева направо: семья Сергея и Надежды → родители → деды → прадеды. Верхняя половина — линия Матюхиных, нижняя — Скиба.</p>
     <div class="stats" style="margin-top:24px">
       <div><b>170</b><span>С УКАЗАННЫМИ РОДИТЕЛЯМИ</span></div>
@@ -411,18 +474,18 @@ footer b{color:var(--champ)}
   </div>
 </section>
 
-<section style="overflow-x:auto;padding-top:20px">
-  <div class="wrap" style="max-width:none"><svg class="pedigree" viewBox="0 0 1140 1637" xmlns="http://www.w3.org/2000/svg" style="min-width:1140px"><text x="12" y="20" class="colhead">СЕМЬЯ</text><text x="198" y="20" class="colhead">РОДИТЕЛИ</text><text x="384" y="20" class="colhead">ДЕДЫ И БАБУШКИ</text><text x="570" y="20" class="colhead">ПРАДЕДЫ</text><text x="756" y="20" class="colhead">ПРАПРАДЕДЫ</text><text x="942" y="20" class="colhead">ПРАПРАПРАДЕДЫ</text><path class="ln" d="M170 460.7 H184.0"/><path class="ln" d="M184.0 328.4 V593.0"/><path class="ln" d="M184.0 328.4 H198"/><path class="ln" d="M356 328.4 H370.0"/><path class="ln" d="M370.0 237.8 V419.0"/><path class="ln" d="M370.0 237.8 H384"/><path class="ln" d="M542 237.8 H556.0"/><path class="ln" d="M556.0 172.5 V303.0"/><path class="ln" d="M556.0 172.5 H570"/><path class="ln" d="M728 172.5 H742.0"/><path class="ln" d="M742.0 129.0 V216.0"/><path class="ln" d="M742.0 129.0 H756"/><path class="ln" d="M914 129.0 H928.0"/><path class="ln" d="M928.0 100.0 V158.0"/><path class="ln" d="M928.0 100.0 H942"/><path class="ln" d="M928.0 158.0 H942"/><path class="ln" d="M742.0 216.0 H756"/><path class="ln" d="M556.0 303.0 H570"/><path class="ln" d="M728 303.0 H742.0"/><path class="ln" d="M742.0 274.0 V332.0"/><path class="ln" d="M742.0 274.0 H756"/><path class="ln" d="M742.0 332.0 H756"/><path class="ln" d="M370.0 419.0 H384"/><path class="ln" d="M542 419.0 H556.0"/><path class="ln" d="M556.0 390.0 V448.0"/><path class="ln" d="M556.0 390.0 H570"/><path class="ln" d="M556.0 448.0 H570"/><path class="ln" d="M184.0 593.0 H198"/><path class="ln" d="M356 593.0 H370.0"/><path class="ln" d="M370.0 535.0 V651.0"/><path class="ln" d="M370.0 535.0 H384"/><path class="ln" d="M542 535.0 H556.0"/><path class="ln" d="M556.0 506.0 V564.0"/><path class="ln" d="M556.0 506.0 H570"/><path class="ln" d="M556.0 564.0 H570"/><path class="ln" d="M370.0 651.0 H384"/><path class="ln" d="M542 651.0 H556.0"/><path class="ln" d="M556.0 622.0 V680.0"/><path class="ln" d="M556.0 622.0 H570"/><path class="ln" d="M556.0 680.0 H570"/><path class="ln" d="M170 1196.6 H184.0"/><path class="ln" d="M184.0 1020.8 V1372.4"/><path class="ln" d="M184.0 1020.8 H198"/><path class="ln" d="M356 1020.8 H370.0"/><path class="ln" d="M370.0 912.0 V1129.5"/><path class="ln" d="M370.0 912.0 H384"/><path class="ln" d="M542 912.0 H556.0"/><path class="ln" d="M556.0 854.0 V970.0"/><path class="ln" d="M556.0 854.0 H570"/><path class="ln" d="M728 854.0 H742.0"/><path class="ln" d="M742.0 825.0 V883.0"/><path class="ln" d="M742.0 825.0 H756"/><path class="ln" d="M742.0 883.0 H756"/><path class="ln" d="M556.0 970.0 H570"/><path class="ln" d="M728 970.0 H742.0"/><path class="ln" d="M742.0 941.0 V999.0"/><path class="ln" d="M742.0 941.0 H756"/><path class="ln" d="M742.0 999.0 H756"/><path class="ln" d="M370.0 1129.5 H384"/><path class="ln" d="M542 1129.5 H556.0"/><path class="ln" d="M556.0 1086.0 V1173.0"/><path class="ln" d="M556.0 1086.0 H570"/><path class="ln" d="M728 1086.0 H742.0"/><path class="ln" d="M742.0 1057.0 V1115.0"/><path class="ln" d="M742.0 1057.0 H756"/><path class="ln" d="M742.0 1115.0 H756"/><path class="ln" d="M556.0 1173.0 H570"/><path class="ln" d="M184.0 1372.4 H198"/><path class="ln" d="M356 1372.4 H370.0"/><path class="ln" d="M370.0 1260.0 V1484.8"/><path class="ln" d="M370.0 1260.0 H384"/><path class="ln" d="M542 1260.0 H556.0"/><path class="ln" d="M556.0 1231.0 V1289.0"/><path class="ln" d="M556.0 1231.0 H570"/><path class="ln" d="M556.0 1289.0 H570"/><path class="ln" d="M370.0 1484.8 H384"/><path class="ln" d="M542 1484.8 H556.0"/><path class="ln" d="M556.0 1419.5 V1550.0"/><path class="ln" d="M556.0 1419.5 H570"/><path class="ln" d="M728 1419.5 H742.0"/><path class="ln" d="M742.0 1376.0 V1463.0"/><path class="ln" d="M742.0 1376.0 H756"/><path class="ln" d="M914 1376.0 H928.0"/><path class="ln" d="M928.0 1347.0 V1405.0"/><path class="ln" d="M928.0 1347.0 H942"/><path class="ln" d="M928.0 1405.0 H942"/><path class="ln" d="M742.0 1463.0 H756"/><path class="ln" d="M556.0 1550.0 H570"/><path class="ln" d="M728 1550.0 H742.0"/><path class="ln" d="M742.0 1521.0 V1579.0"/><path class="ln" d="M742.0 1521.0 H756"/><path class="ln" d="M742.0 1579.0 H756"/><path class="ln" d="M6 460.7 V1196.6"/><path class="ln" d="M6 460.7 H12"/><path class="ln" d="M6 1196.6 H12"/><path class="ln" d="M6 828.6 H12"/><g class="bx me"><rect x="12" y="806.6" width="158" height="44" rx="8"/><text x="22" y="819.6" class="t1">Матюхина</text><text x="22" y="831.6" class="t2">Анна Сергеевна</text><text x="22" y="843.6" class="t3">2002</text></g><g class="bx me"><rect x="12" y="438.7" width="158" height="44" rx="8"/><text x="22" y="451.7" class="t1">Матюхин</text><text x="22" y="463.7" class="t2">Сергей Андреевич</text><text x="22" y="475.7" class="t3">1971</text></g><g class="bx"><rect x="198" y="306.4" width="158" height="44" rx="8"/><text x="208" y="319.4" class="t1">Матюхин</text><text x="208" y="331.4" class="t2">Андрей Иванович</text><text x="208" y="343.4" class="t3">1 октября 1931 – 10 мая 1996</text></g><g class="bx"><rect x="384" y="215.8" width="158" height="44" rx="8"/><text x="394" y="228.8" class="t1">Матюхин</text><text x="394" y="240.8" class="t2">Иван Андреевич</text><text x="394" y="252.8" class="t3">ноя. 1892 – 1971</text></g><g class="bx"><rect x="570" y="150.5" width="158" height="44" rx="8"/><text x="580" y="163.5" class="t1">Матюхин</text><text x="580" y="175.5" class="t2">Андрей Федотович</text><text x="580" y="187.5" class="t3">1870</text></g><g class="bx hyp"><rect x="756" y="107.0" width="158" height="44" rx="8"/><text x="766" y="120.0" class="t1">Матюхин</text><text x="766" y="132.0" class="t2">Федот</text><text x="766" y="144.0" class="t3">до 1852 · гипотеза</text></g><g class="bx hyp"><rect x="942" y="78.0" width="158" height="44" rx="8"/><text x="952" y="91.0" class="t1">Матюхин</text><text x="952" y="103.0" class="t2"></text><text x="952" y="115.0" class="t3">до 1827 · гипотеза</text></g><g class="bx q"><rect x="942" y="136.0" width="158" height="44" rx="8"/><text x="952" y="152.0" class="t1">—</text><text x="952" y="170.0" class="t3">мать не найдена</text></g><g class="bx q"><rect x="756" y="194.0" width="158" height="44" rx="8"/><text x="766" y="210.0" class="t1">—</text><text x="766" y="228.0" class="t3">мать не найдена</text></g><g class="bx"><rect x="570" y="281.0" width="158" height="44" rx="8"/><text x="580" y="294.0" class="t1">Горелова</text><text x="580" y="306.0" class="t2">Мария Федоровна</text><text x="580" y="318.0" class="t3">1871</text></g><g class="bx hyp"><rect x="756" y="252.0" width="158" height="44" rx="8"/><text x="766" y="265.0" class="t1">Горелов</text><text x="766" y="277.0" class="t2">Федор</text><text x="766" y="289.0" class="t3">гипотеза</text></g><g class="bx q"><rect x="756" y="310.0" width="158" height="44" rx="8"/><text x="766" y="326.0" class="t1">—</text><text x="766" y="344.0" class="t3">мать не найдена</text></g><g class="bx"><rect x="384" y="397.0" width="158" height="44" rx="8"/><text x="394" y="410.0" class="t1">Алексанова</text><text x="394" y="422.0" class="t2">Прасковья Власовна</text><text x="394" y="434.0" class="t3">1892 – 1969</text></g><g class="bx hyp"><rect x="570" y="368.0" width="158" height="44" rx="8"/><text x="580" y="381.0" class="t1">Алексанов</text><text x="580" y="393.0" class="t2">Влас</text><text x="580" y="405.0" class="t3">до 1874 · гипотеза</text></g><g class="bx q"><rect x="570" y="426.0" width="158" height="44" rx="8"/><text x="580" y="442.0" class="t1">—</text><text x="580" y="460.0" class="t3">мать не найдена</text></g><g class="bx"><rect x="198" y="571.0" width="158" height="44" rx="8"/><text x="208" y="584.0" class="t1">Астафьева</text><text x="208" y="596.0" class="t2">Надежда Алексеевна</text><text x="208" y="608.0" class="t3">22 августа 1931 – 4 декабря 1997</text></g><g class="bx hyp"><rect x="384" y="513.0" width="158" height="44" rx="8"/><text x="394" y="526.0" class="t1">Астафьев</text><text x="394" y="538.0" class="t2">Алексей Петрович</text><text x="394" y="550.0" class="t3">до 1898 – 22 августа 1972 · гипотеза</text></g><g class="bx hyp"><rect x="570" y="484.0" width="158" height="44" rx="8"/><text x="580" y="497.0" class="t1">Астафьев</text><text x="580" y="509.0" class="t2">Петр</text><text x="580" y="521.0" class="t3">гипотеза</text></g><g class="bx q"><rect x="570" y="542.0" width="158" height="44" rx="8"/><text x="580" y="558.0" class="t1">—</text><text x="580" y="576.0" class="t3">мать не найдена</text></g><g class="bx hyp"><rect x="384" y="629.0" width="158" height="44" rx="8"/><text x="394" y="642.0" class="t1">Мария Архиповна</text><text x="394" y="654.0" class="t2"></text><text x="394" y="666.0" class="t3">† зима 1961 · гипотеза</text></g><g class="bx hyp"><rect x="570" y="600.0" width="158" height="44" rx="8"/><text x="580" y="613.0" class="t1">Архип</text><text x="580" y="625.0" class="t2"></text><text x="580" y="637.0" class="t3">гипотеза</text></g><g class="bx q"><rect x="570" y="658.0" width="158" height="44" rx="8"/><text x="580" y="674.0" class="t1">—</text><text x="580" y="692.0" class="t3">мать не найдена</text></g><g class="bx me"><rect x="12" y="1174.6" width="158" height="44" rx="8"/><text x="22" y="1187.6" class="t1">Скиба</text><text x="22" y="1199.6" class="t2">Надежда Эдуардовна</text><text x="22" y="1211.6" class="t3">1969</text></g><g class="bx"><rect x="198" y="998.8" width="158" height="44" rx="8"/><text x="208" y="1011.8" class="t1">Скиба</text><text x="208" y="1023.8" class="t2">Эдуард Алексеевич</text><text x="208" y="1035.8" class="t3">19 февраля 1937 – 25 мая 2015</text></g><g class="bx"><rect x="384" y="890.0" width="158" height="44" rx="8"/><text x="394" y="903.0" class="t1">Скиба</text><text x="394" y="915.0" class="t2">Алексей Григорьевич</text><text x="394" y="927.0" class="t3">10 апреля 1907 – 13 октября 1955</text></g><g class="bx"><rect x="570" y="832.0" width="158" height="44" rx="8"/><text x="580" y="845.0" class="t1">Скиба</text><text x="580" y="857.0" class="t2">Григорий Андреевич</text><text x="580" y="869.0" class="t3">1879 – после 7 января 1956</text></g><g class="bx hyp"><rect x="756" y="803.0" width="158" height="44" rx="8"/><text x="766" y="816.0" class="t1">Скиба</text><text x="766" y="828.0" class="t2">Андрей Степанович</text><text x="766" y="840.0" class="t3">† 1891 · гипотеза</text></g><g class="bx hyp"><rect x="756" y="861.0" width="158" height="44" rx="8"/><text x="766" y="874.0" class="t1">Пелагея Васильевна</text><text x="766" y="886.0" class="t2"></text><text x="766" y="898.0" class="t3">† 1937 · гипотеза</text></g><g class="bx hyp"><rect x="570" y="948.0" width="158" height="44" rx="8"/><text x="580" y="961.0" class="t1">Захарченкова(Захарченко?)</text><text x="580" y="973.0" class="t2">Зинаида Агеевна</text><text x="580" y="985.0" class="t3">гипотеза</text></g><g class="bx hyp"><rect x="756" y="919.0" width="158" height="44" rx="8"/><text x="766" y="932.0" class="t1">Захарченко</text><text x="766" y="944.0" class="t2">Агей Никифорович</text><text x="766" y="956.0" class="t3">† 1921 · гипотеза</text></g><g class="bx hyp"><rect x="756" y="977.0" width="158" height="44" rx="8"/><text x="766" y="990.0" class="t1">Ульяна Васильевна</text><text x="766" y="1002.0" class="t2"></text><text x="766" y="1014.0" class="t3">† 1947 · гипотеза</text></g><g class="bx"><rect x="384" y="1107.5" width="158" height="44" rx="8"/><text x="394" y="1120.5" class="t1">Алексеева</text><text x="394" y="1132.5" class="t2">Маргарита Васильевна</text><text x="394" y="1144.5" class="t3">8 сентября 1909 – 19 июля 1987</text></g><g class="bx"><rect x="570" y="1064.0" width="158" height="44" rx="8"/><text x="580" y="1077.0" class="t1">Алексеев</text><text x="580" y="1089.0" class="t2">Василий Васильевич</text><text x="580" y="1101.0" class="t3">1875 – 1935</text></g><g class="bx hyp"><rect x="756" y="1035.0" width="158" height="44" rx="8"/><text x="766" y="1048.0" class="t1">Алексеев</text><text x="766" y="1060.0" class="t2">Василий</text><text x="766" y="1072.0" class="t3">гипотеза</text></g><g class="bx q"><rect x="756" y="1093.0" width="158" height="44" rx="8"/><text x="766" y="1109.0" class="t1">—</text><text x="766" y="1127.0" class="t3">мать не найдена</text></g><g class="bx deep"><rect x="570" y="1151.0" width="158" height="44" rx="8"/><text x="580" y="1164.0" class="t1">Агафья Андреевна</text><text x="580" y="1176.0" class="t2"></text><text x="580" y="1188.0" class="t3">1880 – 1944</text></g><g class="bx"><rect x="198" y="1350.4" width="158" height="44" rx="8"/><text x="208" y="1363.4" class="t1">Поташкина</text><text x="208" y="1375.4" class="t2">Нина Федоровна</text><text x="208" y="1387.4" class="t3">11 июня 1938 – 23 апреля 2000</text></g><g class="bx"><rect x="384" y="1238.0" width="158" height="44" rx="8"/><text x="394" y="1251.0" class="t1">Поташкин</text><text x="394" y="1263.0" class="t2">Федор Георгиевич</text><text x="394" y="1275.0" class="t3">23 февраля 1904 – 11 января 1970</text></g><g class="bx hyp"><rect x="570" y="1209.0" width="158" height="44" rx="8"/><text x="580" y="1222.0" class="t1">Поташкин</text><text x="580" y="1234.0" class="t2">Георгий</text><text x="580" y="1246.0" class="t3">† ма1919 · гипотеза</text></g><g class="bx hyp"><rect x="570" y="1267.0" width="158" height="44" rx="8"/><text x="580" y="1280.0" class="t1">Дарья</text><text x="580" y="1292.0" class="t2"></text><text x="580" y="1304.0" class="t3">гипотеза</text></g><g class="bx"><rect x="384" y="1462.8" width="158" height="44" rx="8"/><text x="394" y="1475.8" class="t1">Алексеева</text><text x="394" y="1487.8" class="t2">Серафима Григорьевна</text><text x="394" y="1499.8" class="t3">11 августа 1912 – 26 июля 1988</text></g><g class="bx"><rect x="570" y="1397.5" width="158" height="44" rx="8"/><text x="580" y="1410.5" class="t1">Захаров/Алексеев</text><text x="580" y="1422.5" class="t2">Григорий Спиридонович</text><text x="580" y="1434.5" class="t3">23 января 1887 – 16 ноября 1966</text></g><g class="bx"><rect x="756" y="1354.0" width="158" height="44" rx="8"/><text x="766" y="1367.0" class="t1">Захаров</text><text x="766" y="1379.0" class="t2">Спиридон Ермилович(Ермолаевич)</text><text x="766" y="1391.0" class="t3">1861</text></g><g class="bx hyp"><rect x="942" y="1325.0" width="158" height="44" rx="8"/><text x="952" y="1338.0" class="t1">Захаров</text><text x="952" y="1350.0" class="t2">Ермил(а)/Ермолай</text><text x="952" y="1362.0" class="t3">до 1845 · гипотеза</text></g><g class="bx q"><rect x="942" y="1383.0" width="158" height="44" rx="8"/><text x="952" y="1399.0" class="t1">—</text><text x="952" y="1417.0" class="t3">мать не найдена</text></g><g class="bx deep"><rect x="756" y="1441.0" width="158" height="44" rx="8"/><text x="766" y="1454.0" class="t1">Елизавета Николаевна</text><text x="766" y="1466.0" class="t2"></text><text x="766" y="1478.0" class="t3">1864</text></g><g class="bx"><rect x="570" y="1528.0" width="158" height="44" rx="8"/><text x="580" y="1541.0" class="t1">Елисеева</text><text x="580" y="1553.0" class="t2">Зинаида Петровна</text><text x="580" y="1565.0" class="t3">8 ноября 1888 – 25 февраля 1973</text></g><g class="bx hyp"><rect x="756" y="1499.0" width="158" height="44" rx="8"/><text x="766" y="1512.0" class="t1">Елисеев</text><text x="766" y="1524.0" class="t2">Петр</text><text x="766" y="1536.0" class="t3">гипотеза</text></g><g class="bx q"><rect x="756" y="1557.0" width="158" height="44" rx="8"/><text x="766" y="1573.0" class="t1">—</text><text x="766" y="1591.0" class="t3">мать не найдена</text></g></svg>
+<section class="treewrap">
+  <div class="wrap" style="max-width:none"><svg class="pedigree" viewBox="0 0 1488 2533" xmlns="http://www.w3.org/2000/svg" style="min-width:1488px"><text x="18" y="26" class="colhead">СЕМЬЯ</text><text x="260" y="26" class="colhead">РОДИТЕЛИ</text><text x="502" y="26" class="colhead">ДЕДЫ И БАБУШКИ</text><text x="744" y="26" class="colhead">ПРАДЕДЫ</text><text x="986" y="26" class="colhead">ПРАПРАДЕДЫ</text><text x="1228" y="26" class="colhead">ПРАПРАПРАДЕДЫ</text><path class="ln" d="M232 667.1 H246.0"/><path class="ln" d="M246.0 457.2 V877.0"/><path class="ln" d="M246.0 457.2 H260"/><path class="ln" d="M474 457.2 H488.0"/><path class="ln" d="M488.0 313.5 V601.0"/><path class="ln" d="M488.0 313.5 H502"/><path class="ln" d="M716 313.5 H730.0"/><path class="ln" d="M730.0 210.0 V417.0"/><path class="ln" d="M730.0 210.0 H744"/><path class="ln" d="M958 210.0 H972.0"/><path class="ln" d="M972.0 141.0 V279.0"/><path class="ln" d="M972.0 141.0 H986"/><path class="ln" d="M1200 141.0 H1214.0"/><path class="ln" d="M1214.0 95.0 V187.0"/><path class="ln" d="M1214.0 95.0 H1228"/><path class="ln" d="M1214.0 187.0 H1228"/><path class="ln" d="M972.0 279.0 H986"/><path class="ln" d="M730.0 417.0 H744"/><path class="ln" d="M958 417.0 H972.0"/><path class="ln" d="M972.0 371.0 V463.0"/><path class="ln" d="M972.0 371.0 H986"/><path class="ln" d="M972.0 463.0 H986"/><path class="ln" d="M488.0 601.0 H502"/><path class="ln" d="M716 601.0 H730.0"/><path class="ln" d="M730.0 555.0 V647.0"/><path class="ln" d="M730.0 555.0 H744"/><path class="ln" d="M730.0 647.0 H744"/><path class="ln" d="M246.0 877.0 H260"/><path class="ln" d="M474 877.0 H488.0"/><path class="ln" d="M488.0 785.0 V969.0"/><path class="ln" d="M488.0 785.0 H502"/><path class="ln" d="M716 785.0 H730.0"/><path class="ln" d="M730.0 739.0 V831.0"/><path class="ln" d="M730.0 739.0 H744"/><path class="ln" d="M730.0 831.0 H744"/><path class="ln" d="M488.0 969.0 H502"/><path class="ln" d="M716 969.0 H730.0"/><path class="ln" d="M730.0 923.0 V1015.0"/><path class="ln" d="M730.0 923.0 H744"/><path class="ln" d="M730.0 1015.0 H744"/><path class="ln" d="M232 1834.4 H246.0"/><path class="ln" d="M246.0 1555.5 V2113.2"/><path class="ln" d="M246.0 1555.5 H260"/><path class="ln" d="M474 1555.5 H488.0"/><path class="ln" d="M488.0 1383.0 V1728.0"/><path class="ln" d="M488.0 1383.0 H502"/><path class="ln" d="M716 1383.0 H730.0"/><path class="ln" d="M730.0 1291.0 V1475.0"/><path class="ln" d="M730.0 1291.0 H744"/><path class="ln" d="M958 1291.0 H972.0"/><path class="ln" d="M972.0 1245.0 V1337.0"/><path class="ln" d="M972.0 1245.0 H986"/><path class="ln" d="M972.0 1337.0 H986"/><path class="ln" d="M730.0 1475.0 H744"/><path class="ln" d="M958 1475.0 H972.0"/><path class="ln" d="M972.0 1429.0 V1521.0"/><path class="ln" d="M972.0 1429.0 H986"/><path class="ln" d="M972.0 1521.0 H986"/><path class="ln" d="M488.0 1728.0 H502"/><path class="ln" d="M716 1728.0 H730.0"/><path class="ln" d="M730.0 1659.0 V1797.0"/><path class="ln" d="M730.0 1659.0 H744"/><path class="ln" d="M958 1659.0 H972.0"/><path class="ln" d="M972.0 1613.0 V1705.0"/><path class="ln" d="M972.0 1613.0 H986"/><path class="ln" d="M972.0 1705.0 H986"/><path class="ln" d="M730.0 1797.0 H744"/><path class="ln" d="M246.0 2113.2 H260"/><path class="ln" d="M474 2113.2 H488.0"/><path class="ln" d="M488.0 1935.0 V2291.5"/><path class="ln" d="M488.0 1935.0 H502"/><path class="ln" d="M716 1935.0 H730.0"/><path class="ln" d="M730.0 1889.0 V1981.0"/><path class="ln" d="M730.0 1889.0 H744"/><path class="ln" d="M730.0 1981.0 H744"/><path class="ln" d="M488.0 2291.5 H502"/><path class="ln" d="M716 2291.5 H730.0"/><path class="ln" d="M730.0 2188.0 V2395.0"/><path class="ln" d="M730.0 2188.0 H744"/><path class="ln" d="M958 2188.0 H972.0"/><path class="ln" d="M972.0 2119.0 V2257.0"/><path class="ln" d="M972.0 2119.0 H986"/><path class="ln" d="M1200 2119.0 H1214.0"/><path class="ln" d="M1214.0 2073.0 V2165.0"/><path class="ln" d="M1214.0 2073.0 H1228"/><path class="ln" d="M1214.0 2165.0 H1228"/><path class="ln" d="M972.0 2257.0 H986"/><path class="ln" d="M730.0 2395.0 H744"/><path class="ln" d="M958 2395.0 H972.0"/><path class="ln" d="M972.0 2349.0 V2441.0"/><path class="ln" d="M972.0 2349.0 H986"/><path class="ln" d="M972.0 2441.0 H986"/><path class="ln" d="M12 667.1 V1834.4"/><path class="ln" d="M12 667.1 H18"/><path class="ln" d="M12 1834.4 H18"/><path class="ln" d="M12 1250.8 H18"/><g class="bx ok me"><rect class="fr" x="18" y="1211.8" width="214" height="78" rx="10"/><text class="t1" x="30" y="1228.8">Матюхина</text><text class="t2" x="30" y="1245.8">Анна Сергеевна</text><text class="t3" x="30" y="1263.8">2002</text><rect class="bg" x="30" y="1268.8" width="100" height="16" rx="8.0"/><text class="bdg" x="80.0" y="1280.2" text-anchor="middle">Подтверждено</text></g><g class="bx ok me"><rect class="fr" x="18" y="628.1" width="214" height="78" rx="10"/><text class="t1" x="30" y="645.1">Матюхин</text><text class="t2" x="30" y="662.1">Сергей Андреевич</text><text class="t3" x="30" y="680.1">1971</text><rect class="bg" x="30" y="685.1" width="100" height="16" rx="8.0"/><text class="bdg" x="80.0" y="696.5" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="260" y="418.2" width="214" height="78" rx="10"/><text class="t1" x="272" y="435.2">Матюхин</text><text class="t2" x="272" y="452.2">Андрей Иванович</text><text class="t3" x="272" y="470.2">1 октября 1931 – 10 мая 1996</text><rect class="bg" x="272" y="475.2" width="100" height="16" rx="8.0"/><text class="bdg" x="322.0" y="486.6" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="502" y="274.5" width="214" height="78" rx="10"/><text class="t1" x="514" y="291.5">Матюхин</text><text class="t2" x="514" y="308.5">Иван Андреевич</text><text class="t3" x="514" y="326.5">ноя. 1892 – 1971</text><rect class="bg" x="514" y="331.5" width="100" height="16" rx="8.0"/><text class="bdg" x="564.0" y="342.9" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="744" y="171.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="188.0">Матюхин</text><text class="t2" x="756" y="205.0">Андрей Федотович</text><text class="t3" x="756" y="223.0">1870</text><rect class="bg" x="756" y="228.0" width="100" height="16" rx="8.0"/><text class="bdg" x="806.0" y="239.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="986" y="102.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="119.0">Матюхин</text><text class="t2" x="998" y="136.0">Федот</text><text class="t3" x="998" y="154.0">до 1852</text><rect class="bg" x="998" y="159.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1035.0" y="170.4" text-anchor="middle">Гипотеза</text></g><g class="bx hyp"><rect class="fr" x="1228" y="56.0" width="214" height="78" rx="10"/><text class="t1" x="1240" y="73.0">Матюхин</text><text class="t2" x="1240" y="90.0"></text><text class="t3" x="1240" y="108.0">до 1827</text><rect class="bg" x="1240" y="113.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1277.0" y="124.4" text-anchor="middle">Гипотеза</text></g><g class="bx q"><rect class="fr" x="1228" y="148.0" width="214" height="78" rx="10"/><text class="t1" x="1240" y="165.0">—</text><text class="t2" x="1240" y="182.0">мать не найдена</text><rect class="bg" x="1240" y="205.0" width="86" height="16" rx="8.0"/><text class="bdg" x="1283.0" y="216.4" text-anchor="middle">Нет данных</text></g><g class="bx q"><rect class="fr" x="986" y="240.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="257.0">—</text><text class="t2" x="998" y="274.0">мать не найдена</text><rect class="bg" x="998" y="297.0" width="86" height="16" rx="8.0"/><text class="bdg" x="1041.0" y="308.4" text-anchor="middle">Нет данных</text></g><g class="bx ok"><rect class="fr" x="744" y="378.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="395.0">Горелова</text><text class="t2" x="756" y="412.0">Мария Федоровна</text><text class="t3" x="756" y="430.0">1871</text><rect class="bg" x="756" y="435.0" width="100" height="16" rx="8.0"/><text class="bdg" x="806.0" y="446.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="986" y="332.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="349.0">Горелов</text><text class="t2" x="998" y="366.0">Федор</text><text class="t3" x="998" y="384.0"></text><rect class="bg" x="998" y="389.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1035.0" y="400.4" text-anchor="middle">Гипотеза</text></g><g class="bx q"><rect class="fr" x="986" y="424.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="441.0">—</text><text class="t2" x="998" y="458.0">мать не найдена</text><rect class="bg" x="998" y="481.0" width="86" height="16" rx="8.0"/><text class="bdg" x="1041.0" y="492.4" text-anchor="middle">Нет данных</text></g><g class="bx ok"><rect class="fr" x="502" y="562.0" width="214" height="78" rx="10"/><text class="t1" x="514" y="579.0">Алексанова</text><text class="t2" x="514" y="596.0">Прасковья Власовна</text><text class="t3" x="514" y="614.0">1892 – 1969</text><rect class="bg" x="514" y="619.0" width="100" height="16" rx="8.0"/><text class="bdg" x="564.0" y="630.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="744" y="516.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="533.0">Алексанов</text><text class="t2" x="756" y="550.0">Влас</text><text class="t3" x="756" y="568.0">до 1874</text><rect class="bg" x="756" y="573.0" width="74" height="16" rx="8.0"/><text class="bdg" x="793.0" y="584.4" text-anchor="middle">Гипотеза</text></g><g class="bx q"><rect class="fr" x="744" y="608.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="625.0">—</text><text class="t2" x="756" y="642.0">мать не найдена</text><rect class="bg" x="756" y="665.0" width="86" height="16" rx="8.0"/><text class="bdg" x="799.0" y="676.4" text-anchor="middle">Нет данных</text></g><g class="bx ok"><rect class="fr" x="260" y="838.0" width="214" height="78" rx="10"/><text class="t1" x="272" y="855.0">Астафьева</text><text class="t2" x="272" y="872.0">Надежда Алексеевна</text><text class="t3" x="272" y="890.0">22 августа 1931 – 4 декабря 1997</text><rect class="bg" x="272" y="895.0" width="100" height="16" rx="8.0"/><text class="bdg" x="322.0" y="906.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="502" y="746.0" width="214" height="78" rx="10"/><text class="t1" x="514" y="763.0">Астафьев</text><text class="t2" x="514" y="780.0">Алексей Петрович</text><text class="t3" x="514" y="798.0">до 1898 – 22 августа 1972</text><rect class="bg" x="514" y="803.0" width="74" height="16" rx="8.0"/><text class="bdg" x="551.0" y="814.4" text-anchor="middle">Гипотеза</text></g><g class="bx hyp"><rect class="fr" x="744" y="700.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="717.0">Астафьев</text><text class="t2" x="756" y="734.0">Петр</text><text class="t3" x="756" y="752.0"></text><rect class="bg" x="756" y="757.0" width="74" height="16" rx="8.0"/><text class="bdg" x="793.0" y="768.4" text-anchor="middle">Гипотеза</text></g><g class="bx q"><rect class="fr" x="744" y="792.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="809.0">—</text><text class="t2" x="756" y="826.0">мать не найдена</text><rect class="bg" x="756" y="849.0" width="86" height="16" rx="8.0"/><text class="bdg" x="799.0" y="860.4" text-anchor="middle">Нет данных</text></g><g class="bx hyp"><rect class="fr" x="502" y="930.0" width="214" height="78" rx="10"/><text class="t1" x="514" y="947.0">Мария Архиповна</text><text class="t2" x="514" y="964.0"></text><text class="t3" x="514" y="982.0">† зима 1961</text><rect class="bg" x="514" y="987.0" width="74" height="16" rx="8.0"/><text class="bdg" x="551.0" y="998.4" text-anchor="middle">Гипотеза</text></g><g class="bx hyp"><rect class="fr" x="744" y="884.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="901.0">Архип</text><text class="t2" x="756" y="918.0"></text><text class="t3" x="756" y="936.0"></text><rect class="bg" x="756" y="941.0" width="74" height="16" rx="8.0"/><text class="bdg" x="793.0" y="952.4" text-anchor="middle">Гипотеза</text></g><g class="bx q"><rect class="fr" x="744" y="976.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="993.0">—</text><text class="t2" x="756" y="1010.0">мать не найдена</text><rect class="bg" x="756" y="1033.0" width="86" height="16" rx="8.0"/><text class="bdg" x="799.0" y="1044.4" text-anchor="middle">Нет данных</text></g><g class="bx ok me"><rect class="fr" x="18" y="1795.4" width="214" height="78" rx="10"/><text class="t1" x="30" y="1812.4">Скиба</text><text class="t2" x="30" y="1829.4">Надежда Эдуардовна</text><text class="t3" x="30" y="1847.4">1969</text><rect class="bg" x="30" y="1852.4" width="100" height="16" rx="8.0"/><text class="bdg" x="80.0" y="1863.8" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="260" y="1516.5" width="214" height="78" rx="10"/><text class="t1" x="272" y="1533.5">Скиба</text><text class="t2" x="272" y="1550.5">Эдуард Алексеевич</text><text class="t3" x="272" y="1568.5">19 февраля 1937 – 25 мая 2015</text><rect class="bg" x="272" y="1573.5" width="100" height="16" rx="8.0"/><text class="bdg" x="322.0" y="1584.9" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="502" y="1344.0" width="214" height="78" rx="10"/><text class="t1" x="514" y="1361.0">Скиба</text><text class="t2" x="514" y="1378.0">Алексей Григорьевич</text><text class="t3" x="514" y="1396.0">10 апреля 1907 – 13 октября 1955</text><rect class="bg" x="514" y="1401.0" width="100" height="16" rx="8.0"/><text class="bdg" x="564.0" y="1412.4" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="744" y="1252.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="1269.0">Скиба</text><text class="t2" x="756" y="1286.0">Григорий Андреевич</text><text class="t3" x="756" y="1304.0">1879 – после 7 января 1956</text><rect class="bg" x="756" y="1309.0" width="100" height="16" rx="8.0"/><text class="bdg" x="806.0" y="1320.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="986" y="1206.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="1223.0">Скиба</text><text class="t2" x="998" y="1240.0">Андрей Степанович</text><text class="t3" x="998" y="1258.0">† 1891</text><rect class="bg" x="998" y="1263.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1035.0" y="1274.4" text-anchor="middle">Гипотеза</text></g><g class="bx hyp"><rect class="fr" x="986" y="1298.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="1315.0">Пелагея Васильевна</text><text class="t2" x="998" y="1332.0"></text><text class="t3" x="998" y="1350.0">† 1937</text><rect class="bg" x="998" y="1355.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1035.0" y="1366.4" text-anchor="middle">Гипотеза</text></g><g class="bx hyp"><rect class="fr" x="744" y="1436.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="1453.0">Захарченкова(Захарченко?)</text><text class="t2" x="756" y="1470.0">Зинаида Агеевна</text><text class="t3" x="756" y="1488.0"></text><rect class="bg" x="756" y="1493.0" width="74" height="16" rx="8.0"/><text class="bdg" x="793.0" y="1504.4" text-anchor="middle">Гипотеза</text></g><g class="bx hyp"><rect class="fr" x="986" y="1390.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="1407.0">Захарченко</text><text class="t2" x="998" y="1424.0">Агей Никифорович</text><text class="t3" x="998" y="1442.0">† 1921</text><rect class="bg" x="998" y="1447.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1035.0" y="1458.4" text-anchor="middle">Гипотеза</text></g><g class="bx hyp"><rect class="fr" x="986" y="1482.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="1499.0">Ульяна Васильевна</text><text class="t2" x="998" y="1516.0"></text><text class="t3" x="998" y="1534.0">† 1947</text><rect class="bg" x="998" y="1539.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1035.0" y="1550.4" text-anchor="middle">Гипотеза</text></g><g class="bx ok"><rect class="fr" x="502" y="1689.0" width="214" height="78" rx="10"/><text class="t1" x="514" y="1706.0">Алексеева</text><text class="t2" x="514" y="1723.0">Маргарита Васильевна</text><text class="t3" x="514" y="1741.0">8 сентября 1909 – 19 июля 1987</text><rect class="bg" x="514" y="1746.0" width="100" height="16" rx="8.0"/><text class="bdg" x="564.0" y="1757.4" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="744" y="1620.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="1637.0">Алексеев</text><text class="t2" x="756" y="1654.0">Василий Васильевич</text><text class="t3" x="756" y="1672.0">1875 – 1935</text><rect class="bg" x="756" y="1677.0" width="100" height="16" rx="8.0"/><text class="bdg" x="806.0" y="1688.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="986" y="1574.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="1591.0">Алексеев</text><text class="t2" x="998" y="1608.0">Василий</text><text class="t3" x="998" y="1626.0"></text><rect class="bg" x="998" y="1631.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1035.0" y="1642.4" text-anchor="middle">Гипотеза</text></g><g class="bx q"><rect class="fr" x="986" y="1666.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="1683.0">—</text><text class="t2" x="998" y="1700.0">мать не найдена</text><rect class="bg" x="998" y="1723.0" width="86" height="16" rx="8.0"/><text class="bdg" x="1041.0" y="1734.4" text-anchor="middle">Нет данных</text></g><g class="bx ok deep"><rect class="fr" x="744" y="1758.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="1775.0">Агафья Андреевна</text><text class="t2" x="756" y="1792.0"></text><text class="t3" x="756" y="1810.0">1880 – 1944</text><rect class="bg" x="756" y="1815.0" width="100" height="16" rx="8.0"/><text class="bdg" x="806.0" y="1826.4" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="260" y="2074.2" width="214" height="78" rx="10"/><text class="t1" x="272" y="2091.2">Поташкина</text><text class="t2" x="272" y="2108.2">Нина Федоровна</text><text class="t3" x="272" y="2126.2">11 июня 1938 – 23 апреля 2000</text><rect class="bg" x="272" y="2131.2" width="100" height="16" rx="8.0"/><text class="bdg" x="322.0" y="2142.7" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="502" y="1896.0" width="214" height="78" rx="10"/><text class="t1" x="514" y="1913.0">Поташкин</text><text class="t2" x="514" y="1930.0">Федор Георгиевич</text><text class="t3" x="514" y="1948.0">23 февраля 1904 – 11 января 1970</text><rect class="bg" x="514" y="1953.0" width="100" height="16" rx="8.0"/><text class="bdg" x="564.0" y="1964.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="744" y="1850.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="1867.0">Поташкин</text><text class="t2" x="756" y="1884.0">Георгий</text><text class="t3" x="756" y="1902.0">† ма1919</text><rect class="bg" x="756" y="1907.0" width="74" height="16" rx="8.0"/><text class="bdg" x="793.0" y="1918.4" text-anchor="middle">Гипотеза</text></g><g class="bx hyp"><rect class="fr" x="744" y="1942.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="1959.0">Дарья</text><text class="t2" x="756" y="1976.0"></text><text class="t3" x="756" y="1994.0"></text><rect class="bg" x="756" y="1999.0" width="74" height="16" rx="8.0"/><text class="bdg" x="793.0" y="2010.4" text-anchor="middle">Гипотеза</text></g><g class="bx ok"><rect class="fr" x="502" y="2252.5" width="214" height="78" rx="10"/><text class="t1" x="514" y="2269.5">Алексеева</text><text class="t2" x="514" y="2286.5">Серафима Григорьевна</text><text class="t3" x="514" y="2304.5">11 августа 1912 – 26 июля 1988</text><rect class="bg" x="514" y="2309.5" width="100" height="16" rx="8.0"/><text class="bdg" x="564.0" y="2320.9" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="744" y="2149.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="2166.0">Захаров/Алексеев</text><text class="t2" x="756" y="2183.0">Григорий Спиридонович</text><text class="t3" x="756" y="2201.0">23 января 1887 – 16 ноября 1966</text><rect class="bg" x="756" y="2206.0" width="100" height="16" rx="8.0"/><text class="bdg" x="806.0" y="2217.4" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="986" y="2080.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="2097.0">Захаров</text><text class="t2" x="998" y="2114.0">Спиридон Ермилович(Ермолаевич)</text><text class="t3" x="998" y="2132.0">1861</text><rect class="bg" x="998" y="2137.0" width="100" height="16" rx="8.0"/><text class="bdg" x="1048.0" y="2148.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="1228" y="2034.0" width="214" height="78" rx="10"/><text class="t1" x="1240" y="2051.0">Захаров</text><text class="t2" x="1240" y="2068.0">Ермил(а)/Ермолай</text><text class="t3" x="1240" y="2086.0">до 1845</text><rect class="bg" x="1240" y="2091.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1277.0" y="2102.4" text-anchor="middle">Гипотеза</text></g><g class="bx q"><rect class="fr" x="1228" y="2126.0" width="214" height="78" rx="10"/><text class="t1" x="1240" y="2143.0">—</text><text class="t2" x="1240" y="2160.0">мать не найдена</text><rect class="bg" x="1240" y="2183.0" width="86" height="16" rx="8.0"/><text class="bdg" x="1283.0" y="2194.4" text-anchor="middle">Нет данных</text></g><g class="bx ok deep"><rect class="fr" x="986" y="2218.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="2235.0">Елизавета Николаевна</text><text class="t2" x="998" y="2252.0"></text><text class="t3" x="998" y="2270.0">1864</text><rect class="bg" x="998" y="2275.0" width="100" height="16" rx="8.0"/><text class="bdg" x="1048.0" y="2286.4" text-anchor="middle">Подтверждено</text></g><g class="bx ok"><rect class="fr" x="744" y="2356.0" width="214" height="78" rx="10"/><text class="t1" x="756" y="2373.0">Елисеева</text><text class="t2" x="756" y="2390.0">Зинаида Петровна</text><text class="t3" x="756" y="2408.0">8 ноября 1888 – 25 февраля 1973</text><rect class="bg" x="756" y="2413.0" width="100" height="16" rx="8.0"/><text class="bdg" x="806.0" y="2424.4" text-anchor="middle">Подтверждено</text></g><g class="bx hyp"><rect class="fr" x="986" y="2310.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="2327.0">Елисеев</text><text class="t2" x="998" y="2344.0">Петр</text><text class="t3" x="998" y="2362.0"></text><rect class="bg" x="998" y="2367.0" width="74" height="16" rx="8.0"/><text class="bdg" x="1035.0" y="2378.4" text-anchor="middle">Гипотеза</text></g><g class="bx q"><rect class="fr" x="986" y="2402.0" width="214" height="78" rx="10"/><text class="t1" x="998" y="2419.0">—</text><text class="t2" x="998" y="2436.0">мать не найдена</text><rect class="bg" x="998" y="2459.0" width="86" height="16" rx="8.0"/><text class="bdg" x="1041.0" y="2470.4" text-anchor="middle">Нет данных</text></g></svg>
     <div class="legend">
-      <span><i style="background:rgba(58,16,40,.9);border:1px solid var(--border)"></i>предок с записью в базе</span>
-      <span><i style="border:1px dashed var(--champ2);background:rgba(58,16,40,.55)"></i>гипотеза — нет источника, дата вычислена или отсутствует</span>
-      <span><i style="border:1px dashed var(--line)"></i>предок не найден — цель поиска</span>
-      <span><i style="background:rgba(14,143,75,.25);border:1px solid var(--green)"></i>ныне живущие</span>
+      <span><i class="ok"></i>Подтверждено — предок с записью в базе</span>
+      <span><i class="hyp"></i>Гипотеза — нет источника, дата вычислена или отсутствует</span>
+      <span><i class="q"></i>Нет данных — предок не найден, цель поиска</span>
+      <span><i class="anchor"></i>Семья, от которой ведётся отсчёт</span>
     </div>
   </div>
 </section>
 
-<section style="background:var(--bg2)">
+<section class="alt">
   <div class="wrap">
     <div class="sect-head">
       <div class="label">Что ищем дальше</div>

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -142,12 +142,22 @@ GENERATION_NAMES = {
     6: "шестое поколение",
 }
 
-BOX_W = 158
-BOX_H = 44
-COL_W = 186
-ROW_H = 58
-TOP_PAD = 42
-LEFT_PAD = 12
+BOX_W = 214
+BOX_H = 78
+COL_W = 242
+ROW_H = 92
+TOP_PAD = 56
+LEFT_PAD = 18
+
+STATUS_LABELS = {
+    "ok": "Подтверждено",
+    "hyp": "Гипотеза",
+    "q": "Нет данных",
+}
+# SVG не переносит и не измеряет текст, поэтому ширина плашки задаётся
+# вручную под длину подписи.
+STATUS_BADGE_W = {"ok": 100, "hyp": 74, "q": 86}
+BADGE_H = 16
 
 COLUMN_TITLES = [
     "СЕМЬЯ",
@@ -243,39 +253,57 @@ def render_connectors(node: TreeNode, max_gen: int) -> list[str]:
     return out
 
 
-def render_box(node: TreeNode, max_gen: int) -> str:
+def render_badge(x: float, cy: float, status: str) -> str:
+    """Status pill in the lower-left corner of a tree card."""
+    width = STATUS_BADGE_W[status]
+    return (
+        f'<rect class="bg" x="{x + 12}" y="{cy + 18:.1f}" width="{width}" '
+        f'height="{BADGE_H}" rx="{BADGE_H / 2}"/>'
+        f'<text class="bdg" x="{x + 12 + width / 2:.1f}" y="{cy + 29.4:.1f}" '
+        f'text-anchor="middle">{esc(STATUS_LABELS[status])}</text>'
+    )
+
+
+def render_person_box(x: float, cy: float, person: Person, extra: list[str]) -> str:
+    status = "hyp" if person.is_reconstructed else "ok"
+    surname = person.surname or person.name
+    given = person.name if person.surname else ""
+    years = person.public_years.replace("р. ", "").replace("ум. ", "† ")
+    if years == "? – ?":
+        years = ""
+
+    return (
+        f'<g class="{" ".join(["bx", status, *extra])}">'
+        f'<rect class="fr" x="{x}" y="{cy - BOX_H / 2:.1f}" width="{BOX_W}" height="{BOX_H}" rx="10"/>'
+        f'<text class="t1" x="{x + 12}" y="{cy - 22:.1f}">{esc(surname)}</text>'
+        f'<text class="t2" x="{x + 12}" y="{cy - 5:.1f}">{esc(given)}</text>'
+        f'<text class="t3" x="{x + 12}" y="{cy + 13:.1f}">{esc(years)}</text>'
+        f'{render_badge(x, cy, status)}</g>'
+    )
+
+
+def render_box(node: TreeNode) -> str:
     x = LEFT_PAD + node.gen * COL_W
-    y = node.y - BOX_H / 2
 
     if node.is_missing:
         return (
-            f'<g class="bx q"><rect x="{x}" y="{y:.1f}" width="{BOX_W}" height="{BOX_H}" rx="8"/>'
-            f'<text x="{x + 10}" y="{node.y - 6:.1f}" class="t1">—</text>'
-            f'<text x="{x + 10}" y="{node.y + 12:.1f}" class="t3">{esc(node.placeholder)}</text></g>'
+            f'<g class="bx q">'
+            f'<rect class="fr" x="{x}" y="{node.y - BOX_H / 2:.1f}" '
+            f'width="{BOX_W}" height="{BOX_H}" rx="10"/>'
+            f'<text class="t1" x="{x + 12}" y="{node.y - 22:.1f}">—</text>'
+            f'<text class="t2" x="{x + 12}" y="{node.y - 5:.1f}">{esc(node.placeholder)}</text>'
+            f'{render_badge(x, node.y, "q")}</g>'
         )
 
     person = node.person
     assert person is not None
-    classes = ["bx"]
+    extra: list[str] = []
     if node.gen == 0:
-        classes.append("me")
-    elif person.is_reconstructed:
-        classes.append("hyp")
-    elif not node.children and person.birt:
-        classes.append("deep")
+        extra.append("me")
+    elif not node.children and person.birt and not person.is_reconstructed:
+        extra.append("deep")
 
-    surname = person.surname or person.name
-    given = person.name if person.surname else ""
-    years = person.public_years.replace("р. ", "").replace("ум. ", "† ")
-    if person.is_reconstructed and not person.is_living:
-        years = f"{years} · гипотеза" if years != "? – ?" else "гипотеза"
-
-    return (
-        f'<g class="{" ".join(classes)}"><rect x="{x}" y="{y:.1f}" width="{BOX_W}" height="{BOX_H}" rx="8"/>'
-        f'<text x="{x + 10}" y="{node.y - 9:.1f}" class="t1">{esc(surname)}</text>'
-        f'<text x="{x + 10}" y="{node.y + 3:.1f}" class="t2">{esc(given)}</text>'
-        f'<text x="{x + 10}" y="{node.y + 15:.1f}" class="t3">{esc(years)}</text></g>'
-    )
+    return render_person_box(x, node.y, person, extra)
 
 
 def render_pedigree_svg(
@@ -290,7 +318,7 @@ def render_pedigree_svg(
     father_tree = build_ancestor_tree(root.id, people, families, max_gen)
     mother_tree = build_ancestor_tree(spouse.id, people, families, max_gen)
 
-    cursor = [TOP_PAD + ROW_H]
+    cursor = [TOP_PAD + BOX_H / 2]
     assign_positions(father_tree, cursor)
     cursor[0] += ROW_H * 1.5
     assign_positions(mother_tree, cursor)
@@ -301,7 +329,7 @@ def render_pedigree_svg(
 
     parts: list[str] = []
     for index, title in enumerate(COLUMN_TITLES[: max_gen + 1]):
-        parts.append(f'<text x="{LEFT_PAD + index * COL_W}" y="20" class="colhead">{esc(title)}</text>')
+        parts.append(f'<text x="{LEFT_PAD + index * COL_W}" y="26" class="colhead">{esc(title)}</text>')
 
     parts.extend(render_connectors(father_tree, max_gen))
     parts.extend(render_connectors(mother_tree, max_gen))
@@ -316,17 +344,10 @@ def render_pedigree_svg(
     if child:
         y_child = (father_tree.y + mother_tree.y) / 2
         parts.append(f'<path class="ln" d="M{x_mid} {y_child:.1f} H{LEFT_PAD}"/>')
-        parts.append(
-            f'<g class="bx me"><rect x="{LEFT_PAD}" y="{y_child - BOX_H / 2:.1f}" '
-            f'width="{BOX_W}" height="{BOX_H}" rx="8"/>'
-            f'<text x="{LEFT_PAD + 10}" y="{y_child - 9:.1f}" class="t1">{esc(child.surname)}</text>'
-            f'<text x="{LEFT_PAD + 10}" y="{y_child + 3:.1f}" class="t2">{esc(child.name)}</text>'
-            f'<text x="{LEFT_PAD + 10}" y="{y_child + 15:.1f}" class="t3">'
-            f'{esc(child.public_years.replace("р. ", ""))}</text></g>'
-        )
+        parts.append(render_person_box(LEFT_PAD, y_child, child, ["me"]))
 
     for node in nodes:
-        parts.append(render_box(node, max_gen))
+        parts.append(render_box(node))
 
     width = LEFT_PAD * 2 + (max_gen + 1) * COL_W
     height = max(node.y for node in nodes) + ROW_H
@@ -445,13 +466,13 @@ def build_html(people: dict[str, Person], families: dict[str, Family], meta: dic
     <div class="label">Семейный архив · MyHeritage · экспорт {esc(export_date)}</div>
     <h1>Летопись рода Матюхиных и Скиба</h1>
     <p class="sub">Две главные линии — <b>Матюхины</b> из села Мокрое Тульской губернии и <b>Скибы</b> с донбасской Лозовой Павловки — сошлись в семье Сергея и Надежды. Тульская земля и Донбасс, Валдай и Татария, Подмосковье; {counted(st['people'], ('человек', 'человека', 'человек'))} в базе, {counted(st['surnames'], ('фамилия', 'фамилии', 'фамилий'))}, {counted(documented_gens, ('поколение', 'поколения', 'поколений'))} прослежено.</p>
-    <p class="sub" style="font-size:15px;margin-top:-14px">Страница собрана автоматически из семейного древа MyHeritage. Точные даты, места рождения и контактные данные ныне живущих не публикуются; указаны только имена и годы рождения.</p>
+    <p class="sub note">Страница собрана автоматически из семейного древа MyHeritage. Точные даты, места рождения и контактные данные ныне живущих не публикуются; указаны только имена и годы рождения.</p>
     <button class="btn" onclick="showPage(2)">Открыть древо</button>
     <div class="stats">
       <div><b>{documented_gens}</b><span>{plural(documented_gens, ('ПОКОЛЕНИЕ', 'ПОКОЛЕНИЯ', 'ПОКОЛЕНИЙ'))} ПРОСЛЕЖЕНО</span></div>
       <div><b>{st['people']}</b><span>{plural(st['people'], ('ЧЕЛОВЕК', 'ЧЕЛОВЕКА', 'ЧЕЛОВЕК'))} В БАЗЕ</span></div>
       <div><b>{st['surnames']}</b><span>РОДОВЫХ ФАМИЛИЙ</span></div>
-      <div><b>{st['earliest_year'] or 'XIX в.'}</b><span>ГОД РОЖДЕНИЯ САМОГО РАННЕГО ПРЕДКА</span></div>
+      <div><b>{st['earliest_year'] or 'XIX в.'}</b><span>САМОЕ РАННЕЕ РОЖДЕНИЕ</span></div>
     </div>
   </div>
 </div>
@@ -527,7 +548,7 @@ def build_html(people: dict[str, Person], families: dict[str, Family], meta: dic
   </div>
 </section>
 
-<section style="background:var(--bg2)">
+<section class="alt">
   <div class="wrap">
     <div class="sect-head">
       <div class="label">Самая длинная прослеженная линия</div>
@@ -552,7 +573,7 @@ def build_html(people: dict[str, Person], families: dict[str, Family], meta: dic
   </div>
 </section>
 
-<section style="background:var(--bg2)">
+<section class="alt">
   <div class="wrap">
     <div class="sect-head">
       <div class="label">География</div>
@@ -643,10 +664,10 @@ def build_html(people: dict[str, Person], families: dict[str, Family], meta: dic
 </div>
 
 <div class="page" id="page2">
-<section class="hero" style="padding:60px 0 40px">
+<section class="hero hero-compact">
   <div class="wrap">
     <div class="label">Страница 2 · визуальное древо · прямые предки</div>
-    <h1 style="font-size:clamp(34px,4vw,56px)">Древо прямых предков</h1>
+    <h1>Древо прямых предков</h1>
     <p class="sub">Читается слева направо: семья Сергея и Надежды → родители → деды → прадеды. Верхняя половина — линия Матюхиных, нижняя — Скиба.</p>
     <div class="stats" style="margin-top:24px">
       <div><b>{len([p for p in people.values() if p.famc])}</b><span>С УКАЗАННЫМИ РОДИТЕЛЯМИ</span></div>
@@ -655,18 +676,18 @@ def build_html(people: dict[str, Person], families: dict[str, Family], meta: dic
   </div>
 </section>
 
-<section style="overflow-x:auto;padding-top:20px">
+<section class="treewrap">
   <div class="wrap" style="max-width:none">{pedigree_svg}
     <div class="legend">
-      <span><i style="background:rgba(58,16,40,.9);border:1px solid var(--border)"></i>предок с записью в базе</span>
-      <span><i style="border:1px dashed var(--champ2);background:rgba(58,16,40,.55)"></i>гипотеза — нет источника, дата вычислена или отсутствует</span>
-      <span><i style="border:1px dashed var(--line)"></i>предок не найден — цель поиска</span>
-      <span><i style="background:rgba(14,143,75,.25);border:1px solid var(--green)"></i>ныне живущие</span>
+      <span><i class="ok"></i>Подтверждено — предок с записью в базе</span>
+      <span><i class="hyp"></i>Гипотеза — нет источника, дата вычислена или отсутствует</span>
+      <span><i class="q"></i>Нет данных — предок не найден, цель поиска</span>
+      <span><i class="anchor"></i>Семья, от которой ведётся отсчёт</span>
     </div>
   </div>
 </section>
 
-<section style="background:var(--bg2)">
+<section class="alt">
   <div class="wrap">
     <div class="sect-head">
       <div class="label">Что ищем дальше</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Полная замена визуального стиля без изменения структуры, данных и функциональности страницы. Разметка, тексты, состав разделов, GEDCOM-логика и переключение страниц остались как были.

[Первый экран, десктоп](https://cursor.com/agents/bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhero-desktop.png)

### Палитра

Тёмно-бордовая тема заменена тёплым молочным «бумажным» фоном:

| Роль | Цвет |
| --- | --- |
| Фон | `#F4F0E8` |
| Поверхности и карточки | `#FCFAF6` |
| Основной текст | `#252321` |
| Вторичный текст | `#756F68` |
| Главный акцент | `#76536C` (сливовый) |
| Дополнительный акцент | `#7B806C` (серо-оливковый) |
| Линии и границы | `#D8D0C5` |

Дополнительно введён тон `--ink-3` (`#5C574F`) для мелкого текста 12–14 px: вторичный `#756F68` на молочном фоне даёт контраст 4.3 : 1 и не добирает до AA на малых размерах.

### Типографика

Заголовки — Cormorant Garamond, интерфейс и основной текст — Inter. Базовый кегль поднят с 17 до 18 px (17 px на мобильных), текст в карточках — 16 px.

### Оформление

- Убраны тёмные плашки секций (`background: var(--bg2)`), радиальные градиенты в hero, тяжёлые тени и сепия-фильтры на фотографиях.
- Чередование секций сделано едва заметной сменой тона бумаги (`.alt`).
- Статистика оформлена крупными цифрами под тонкой линейкой, с короткими подписями вместо дашбордных плашек.
- Кнопки и активная кнопка навигации — спокойный сливовый акцент, скругление 10 px, без градиентов.
- Из декоративного оставлены только короткая линейка перед надзаголовком и одно тонкое кольцо в hero.
- Фотографические врезки (`.ph`, `.wcard`) переоформлены как архивные: тонкая рамка, светлое паспарту, сухая подпись без сепии.

[Первый экран, мобильная версия](https://cursor.com/agents/bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhero-mobile.png)

### Древо

[Карточки древа с бейджами статуса](https://cursor.com/agents/bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftree-statuses.png)

- Светлый нейтральный фон, карточки на `--surface` с тонкой рамкой и минимальной тенью. Гендерного деления по цвету не было и не появилось.
- Статус данных кодируется цветом рамки и бейджем: «Подтверждено» — серо-оливковый, «Гипотеза» — сливовый, «Нет данных» — светло-серый пунктир без подложки и тени.
- Статус вычисляется независимо от позиции в древе, поэтому карточки семьи-якоря тоже его показывают; сама семья выделена плотной заливкой, а не отдельным цветом.
- Суффикс `· гипотеза` в строке дат убран как дублирующий бейдж.
- Геометрия карточек увеличена (`214 × 78` вместо `158 × 44`), чтобы полные даты и длинные отчества не выходили за рамку — раньше самые длинные подписи вылезали в межколоночный зазор.
- Легенда переписана под три статуса; инлайновые цвета заменены семантическими классами.

## Проверка

Страница отрендерена в headless Chrome на 1440 × 1000 и 390 × 844. Автоматический аудит подтвердил: горизонтальных переполнений вне области древа нет, ни одна подпись в SVG не выходит за пределы своей карточки. Горизонтальная прокрутка древа сохранена, полоса прокрутки стилизована.

## Изменённые файлы

- `assets/site.css` — дизайн-система переписана целиком: токены, типографика, компоненты, статусы древа, адаптив.
- `scripts/build_site.py` — только места, где цвет и типографика были зашиты в разметку: тёмные плашки секций заменены классом `.alt`, инлайновые стили hero и контейнера древа — классами `.hero-compact`, `.note`, `.treewrap`, легенда переведена на классы статусов, подпись у цифры сокращена. Отрисовка карточек древа вынесена в `render_person_box()` / `render_badge()`, чтобы карточка ребёнка и карточки предков строились одним кодом.
- `index.html` — пересобран генератором.

## На что посмотреть при ревью

- Ширина SVG древа выросла с 1140 до 1488 px, поэтому на десктопе оно теперь прокручивается по горизонтали (раньше почти вмещалось). Это плата за читаемые карточки; альтернатива — вернуть мелкий кегль подписей.
- Из системы убрано выделение «самого дальнего прослеженного предка» отдельным цветом: `.deep` теперь отличается только плотностью рамки, чтобы не вводить четвёртый цвет помимо трёх статусов.
- Подпись у самой ранней даты сокращена с «ГОД РОЖДЕНИЯ САМОГО РАННЕГО ПРЕДКА» до «САМОЕ РАННЕЕ РОЖДЕНИЕ» — это единственная правка текста, сделана ради требования «короткие подписи» у крупных цифр.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

