### PR TITLE
Clarify generator and privacy responsibilities in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ merge в master ──► GitHub Actions ──► gh-pages ──► GitHub Pag
 
 | Слой | Источник | Ответственность |
 |------|----------|-----------------|
-| **Данные** | `data/skiba.ged` | Имена, даты, связи, статистика |
+| **Данные** | `data/skiba.ged` + `scripts/parse_gedcom.py` | Имена, даты, связи, статистика, фильтрация приватности |
 | **Контент** | `content/content.yaml` | Заголовки, абзацы, подписи, легенда |
-| **Генератор** | `scripts/build_site.py` | Сборка HTML, SVG-древо, фильтрация приватности |
+| **Генератор** | `scripts/build_site.py` | Модульный рендер секций, SVG-древо, валидация YAML, post-build проверка приватности |
 | **Публикация** | `.github/workflows/pages.yml` | Деплой только статических файлов в `gh-pages` |
 
 ---
@@ -106,8 +106,8 @@ python3 -m http.server 8080
 |------|------------|
 | `data/skiba.ged` | GEDCOM-экспорт, локально, в Git не попадает |
 | `content/content.yaml` | Редактируемые тексты сайта |
-| `scripts/parse_gedcom.py` | Парсер GEDCOM, модель персон, приватность |
-| `scripts/build_site.py` | Генератор `index.html`, валидация YAML |
+| `scripts/parse_gedcom.py` | Парсер GEDCOM, модель персон, фильтрация приватности |
+| `scripts/build_site.py` | Генератор `index.html`: `render_*` секции, валидация YAML, post-build проверка |
 | `assets/site.css` | Стили |
 | `index.html` | Собранный сайт (коммитится в `master`) |
 | `requirements.txt` | Python-зависимости |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Minor README clarification after build_site.py refactor:

- Split privacy (parse_gedcom) vs post-build validation (build_site) in architecture table
- Document modular `render_*` section structure in repo layout table
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

