### PR TITLE
Docs: fix hero allowlist and asset roles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ merge в master ──► GitHub Actions ──► gh-pages ──► GitHub Pag
 
 **Валидация YAML.** `build_site.py` проверяет обязательные ключи и типы в `content/content.yaml` и падает с понятным сообщением, если структура нарушена.
 
-**Безопасная публикация.** Workflow публикует в `gh-pages` только allowlist: `index.html`, `.nojekyll` и производные фона первого экрана `assets/hero-bg{,-768,-1280}.{avif,webp,jpg}`. CSS инлайнится при сборке; мастер-арт первого экрана (`assets/Image 1.png`) в Pages не попадает — отдаются только сжатые responsive-варианты, а не base64 и не исходный PNG. Скрипты, YAML и служебные файлы на live-сайт не уходят. Репозиторий — чистый Python-генератор без Jekyll/Ruby/reveal.js.
+**Безопасная публикация.** Workflow публикует в `gh-pages` только allowlist: `index.html`, `.nojekyll` и производные фона первого экрана `assets/hero-bg{,-768,-1280}.{avif,webp,jpg}`. CSS инлайнится при сборке; мастер-арт hero-секции (`assets/Image 1.png`) в Pages не попадает — отдаются только сжатые responsive-варианты, а не base64 и не исходный PNG. Скрипты, YAML и служебные файлы на live-сайт не уходят. Репозиторий — чистый Python-генератор без Jekyll/Ruby/reveal.js.
 
 **Ассеты первого экрана.** Фон — мастер `assets/Image 1.png`; раскладка заголовка, навигации и дат сверстана по референсу `assets/Image 2.png`. В прод уходят только производные AVIF → WebP → JPEG (ширины 768 / 1280 / 1376) с preload LCP-кандидата.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ merge в master ──► GitHub Actions ──► gh-pages ──► GitHub Pag
 
 **Валидация YAML.** `build_site.py` проверяет обязательные ключи и типы в `content/content.yaml` и падает с понятным сообщением, если структура нарушена.
 
-**Безопасная публикация.** Workflow публикует в `gh-pages` только allowlist: `index.html`, `.nojekyll` и производные фона первого экрана `assets/hero-bg{,-768,-1280}.{avif,webp,jpg}`. CSS инлайнится при сборке; мастер-арт hero-секции (`assets/Image 1.png`) в Pages не попадает — отдаются только сжатые responsive-варианты, а не base64 и не исходный PNG. Скрипты, YAML и служебные файлы на live-сайт не уходят. Репозиторий — чистый Python-генератор без Jekyll/Ruby/reveal.js.
+**Безопасная публикация.** Workflow публикует в `gh-pages` только allowlist: `index.html`, `.nojekyll` и производные фона первого экрана `assets/hero-bg{,-768,-1280}.{avif,webp,jpg}`. CSS инлайнится при сборке; исходный **hero background** (`assets/Image 1.png`) в Pages не попадает — отдаются только сжатые responsive-варианты, а не base64 и не исходный PNG. Скрипты, YAML и служебные файлы на live-сайт не уходят. Репозиторий — чистый Python-генератор без Jekyll/Ruby/reveal.js.
 
 **Ассеты первого экрана.** Фон — мастер `assets/Image 1.png`; раскладка заголовка, навигации и дат сверстана по референсу `assets/Image 2.png`. В прод уходят только производные AVIF → WebP → JPEG (ширины 768 / 1280 / 1376) с preload LCP-кандидата.
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ merge в master ──► GitHub Actions ──► gh-pages ──► GitHub Pag
 
 **Валидация YAML.** `build_site.py` проверяет обязательные ключи и типы в `content/content.yaml` и падает с понятным сообщением, если структура нарушена.
 
-**Безопасная публикация.** Workflow публикует в `gh-pages` только allowlist: `index.html`, `.nojekyll` и производные фона героя `assets/hero-bg{,-768,-1280}.{avif,webp,jpg}`. CSS инлайнится при сборке; мастер-арт героя (`assets/Image 1.png`) в Pages не попадает — отдаются только сжатые responsive-варианты, а не base64 и не исходный PNG. Скрипты, YAML и служебные файлы на live-сайт не уходят. Репозиторий — чистый Python-генератор без Jekyll/Ruby/reveal.js.
+**Безопасная публикация.** Workflow публикует в `gh-pages` только allowlist: `index.html`, `.nojekyll` и производные фона первого экрана `assets/hero-bg{,-768,-1280}.{avif,webp,jpg}`. CSS инлайнится при сборке; мастер-арт первого экрана (`assets/Image 1.png`) в Pages не попадает — отдаются только сжатые responsive-варианты, а не base64 и не исходный PNG. Скрипты, YAML и служебные файлы на live-сайт не уходят. Репозиторий — чистый Python-генератор без Jekyll/Ruby/reveal.js.
 
-**Hero-ассеты.** Фон героя — мастер `assets/Image 1.png`; раскладка заголовка, навигации и дат сверстана по референсу `assets/Image 2.png`. В прод уходят только производные AVIF → WebP → JPEG (ширины 768 / 1280 / 1376) с preload LCP-кандидата.
+**Ассеты первого экрана.** Фон — мастер `assets/Image 1.png`; раскладка заголовка, навигации и дат сверстана по референсу `assets/Image 2.png`. В прод уходят только производные AVIF → WebP → JPEG (ширины 768 / 1280 / 1376) с preload LCP-кандидата.
 
 **Осознанный trade-off.** Сборка не выполняется в CI: GEDCOM содержит персональные данные и остаётся локально. Перед merge в `master` обновлённый `index.html` коммитится вручную после локальной пересборки.
 
@@ -142,8 +142,8 @@ python3 -m http.server 8080
 | `scripts/parse_gedcom.py` | Парсер GEDCOM, модель персон, фильтрация приватности, вставка предков по архивным находкам (ревизия 1834 г.) |
 | `scripts/build_site.py` | Генератор `index.html`: `render_*` секции, валидация YAML, post-build проверка |
 | `assets/site.css` | Стили (инлайнятся в HTML при сборке) |
-| `assets/Image 1.png`, `assets/Image 2.png` | Мастер фона героя и референс раскладки (в Pages не публикуются) |
-| `assets/hero-bg*.{avif,webp,jpg}` | Оптимизированные производные фона — входят в allowlist `gh-pages` |
+| `assets/Image 1.png`, `assets/Image 2.png` | Мастер фона первого экрана и референс раскладки (в Pages не публикуются) |
+| `assets/hero-bg*.{avif,webp,jpg}` | Оптимизированные производные фона первого экрана — входят в allowlist `gh-pages` |
 | `index.html` | Собранный сайт (коммитится в `master`) |
 | `requirements.txt` | Python-зависимости |
 | `.github/workflows/pages.yml` | Автопубликация в `gh-pages` |

--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ content/content.yaml    ──────────────────�
 assets/site.css         ──────────────────────────────────┘
                                                           │
 merge в master ──► GitHub Actions ──► gh-pages ──► GitHub Pages
-                                      (только index.html,
-                                       assets/hero-reference.png,
-                                       .nojekyll)
+                                      (только index.html, .nojekyll
+                                       и assets/hero-bg*.{avif,webp,jpg})
 ```
 
 | Слой | Источник | Ответственность |
@@ -77,7 +76,9 @@ merge в master ──► GitHub Actions ──► gh-pages ──► GitHub Pag
 
 **Валидация YAML.** `build_site.py` проверяет обязательные ключи и типы в `content/content.yaml` и падает с понятным сообщением, если структура нарушена.
 
-**Безопасная публикация.** Workflow публикует в `gh-pages` только allowlist: `index.html`, `assets/hero-reference.png`, `.nojekyll`. CSS инлайнится при сборке; фоновая композиция героя отдаётся файлом, а не base64 — иначе страница выросла бы на 16 МБ. Скрипты, YAML и служебные файлы на live-сайт не попадают. Репозиторий — чистый Python-генератор без Jekyll/Ruby/reveal.js.
+**Безопасная публикация.** Workflow публикует в `gh-pages` только allowlist: `index.html`, `.nojekyll` и производные фона героя `assets/hero-bg{,-768,-1280}.{avif,webp,jpg}`. CSS инлайнится при сборке; мастер-арт героя (`assets/Image 1.png`) в Pages не попадает — отдаются только сжатые responsive-варианты, а не base64 и не исходный PNG. Скрипты, YAML и служебные файлы на live-сайт не уходят. Репозиторий — чистый Python-генератор без Jekyll/Ruby/reveal.js.
+
+**Hero-ассеты.** Фон героя — мастер `assets/Image 1.png`; раскладка заголовка, навигации и дат сверстана по референсу `assets/Image 2.png`. В прод уходят только производные AVIF → WebP → JPEG (ширины 768 / 1280 / 1376) с preload LCP-кандидата.
 
 **Осознанный trade-off.** Сборка не выполняется в CI: GEDCOM содержит персональные данные и остаётся локально. Перед merge в `master` обновлённый `index.html` коммитится вручную после локальной пересборки.
 
@@ -141,6 +142,8 @@ python3 -m http.server 8080
 | `scripts/parse_gedcom.py` | Парсер GEDCOM, модель персон, фильтрация приватности, вставка предков по архивным находкам (ревизия 1834 г.) |
 | `scripts/build_site.py` | Генератор `index.html`: `render_*` секции, валидация YAML, post-build проверка |
 | `assets/site.css` | Стили (инлайнятся в HTML при сборке) |
+| `assets/Image 1.png`, `assets/Image 2.png` | Мастер фона героя и референс раскладки (в Pages не публикуются) |
+| `assets/hero-bg*.{avif,webp,jpg}` | Оптимизированные производные фона — входят в allowlist `gh-pages` |
 | `index.html` | Собранный сайт (коммитится в `master`) |
 | `requirements.txt` | Python-зависимости |
 | `.github/workflows/pages.yml` | Автопубликация в `gh-pages` |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Three short README accuracy fixes after the hero restyle, plus terminology polish:

1. Architecture diagram — publish allowlist is `hero-bg*.{avif,webp,jpg}`, not `hero-reference.png`
2. Engineering notes — corrected safe-publish list + assets of the first screen (Image 1 master / Image 2 layout)
3. Repository table — rows for master/reference art and published `hero-bg*` files
4. Publish note wording now uses **hero background** for `assets/Image 1.png`

## Test plan
- [ ] Skim README against `.github/workflows/pages.yml` allowlist
- [ ] Confirm no misleading `hero-reference.png` publish claims remain
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

