### PR TITLE
Add project-anchor.md for new chat context

### DIFF
--- a/assets/project-anchor.md
+++ b/assets/project-anchor.md
@@ -1,0 +1,27 @@
+# Якорь контекста проекта
+
+Короткий стартовый контекст для нового чата Cursor.  
+Подробности: [README](../README.md) и [docs/architecture.md](../docs/architecture.md).
+
+## Готово на `master`
+
+- **Live:** https://smaturus.github.io/github-slideshow/
+- **Репозиторий:** Smaturus/github-slideshow
+- **README** — короткий обзор; глубина — в `docs/architecture.md`
+- **Hero:** фон = `assets/Image 1.png`; раскладка = `assets/Image 2.png`
+- **Pages allowlist:** `index.html`, `.nojekyll`, `assets/hero-bg*.{avif,webp,jpg}`
+- **Сборка:** локально `python3 scripts/build_site.py` (GEDCOM не в CI, файл `data/skiba.ged` не в Git)
+
+## Как использовать в новом чате
+
+Скопируйте блок ниже в первое сообщение и допишите задачу:
+
+```text
+Контекст: @assets/project-anchor.md
+(или вставь содержимое этого файла)
+
+Новая задача:
+<опишите, что нужно сделать>
+```
+
+Либо в Cursor: `@` → файл `assets/project-anchor.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `assets/project-anchor.md` — a short context starter for new Cursor chats (live URL, hero assets, Pages allowlist, local build notes).

Intended to be merged to `master` for reuse via `@assets/project-anchor.md`.

## Test plan
- [ ] Open `assets/project-anchor.md` on master
- [ ] Confirm links to README and docs/architecture.md resolve
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c617df4-90f7-4ca0-a279-93e5ae8a3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

